### PR TITLE
Searching for and Compiling a List of Granule IDs for Batch Processing Notebook

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -17,8 +17,9 @@ Welcome to the MAAP User Documentation!
   :caption: Search:
 
   search/granules.ipynb
+  search/searching_compiling_list_of_granule_ids.ipynb
   search/cmr_collection_table.ipynb
-
+  
 
 .. toctree::
   :maxdepth: 2

--- a/docs/source/search/searching_compiling_list_of_granule_ids.ipynb
+++ b/docs/source/search/searching_compiling_list_of_granule_ids.ipynb
@@ -1,0 +1,150 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Searching for and Compiling a List of Granule IDs for Batch Processing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "While using the MAAP ADE, you may wish to create a list of granule IDs to be used for batch processing, granules being the individual files from a sensor that are used for processing. For this example, we will imagine a scenario that we wish to produce a biomass estimate for a single Landsat tile, and then expand that estimate over a larger area. In order to produce this expanded estimate, we will create a list of the Landsat files which fall within a certain area. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We start by importing the `MAAP` and `pprint` packages and creating a new MAAP class."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# import the MAAP package\n",
+    "from maap.maap import MAAP\n",
+    "\n",
+    "# import printing package to help display outputs\n",
+    "from pprint import pprint\n",
+    "\n",
+    "# create MAAP class\n",
+    "maap = MAAP()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We can use the `searchGranule` function to search for Landsat 8 granules. Click [here](https://maap-project.readthedocs.io/en/latest/search/granules.html) for more information about searching for granules with the `searchGranule` function. Since the default limit on results from the MAAP API is 20, we specify a variable to use in our search query. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# get at max 1000 results from CMR\n",
+    "MAXRESULTS = 1000"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To filter our search to Landsat 8 data, we create a variable with the collection ID of the Landsat 8 OLI Surface Reflectance Analysis Ready Data collection. You can find this collection ID as well as the collection IDs for all of the collections in MAAP in the following table within the documentation: https://maap-project.readthedocs.io/en/latest/search/cmr_collection_table.html. Using the Collection Concept ID is the preferred method to filter by a collection, as it is a unique identifier which avoids ambiguity."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "COLLECTIONID = 'C1200110769-NASA_MAAP' # specifying the collection ID for the Landsat 8 dataset"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next, we search for granules using the collection ID and a spatial filter. We can use a bounding box as our spatial filter. The bounding box is a sequence of four latitude and longitude values in the order of [W,S,E,N]. For this example, let's search for granules from the Landsat 8 data using a bounding box for the country Peru."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'Got 805 results'\n"
+     ]
+    }
+   ],
+   "source": [
+    "collectionDomain = '-81.4109425524,-18.3479753557,-68.6650797187,-0.0572054988649' # specify bounding box to search by\n",
+    "\n",
+    "# getting results from granule search using the bounding box, collection ID, and results limit\n",
+    "results = maap.searchGranule(bounding_box=collectionDomain,concept_id=COLLECTIONID,limit=MAXRESULTS) \n",
+    "pprint(f'Got {len(results)} results') # print the number of results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We were able to get 805 results. Each element in the list `results` contains the metadata for one of the granules returned by the search. Within this metadata is the key `concept-id`, which is the unique identifier for each granule. To create a list of granule IDs, we create a new list and use a for loop to add the `concept-id` from each element of `results` into the new list."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "granuleID_list = [] # create list for granule IDs\n",
+    "\n",
+    "for result in results: # loop through each element (granule) in the list `results`\n",
+    "    granuleID_list.append(result['concept-id']) # add the concept id for each granule to `granuleID_list`\n",
+    "    # Tip: you can use `print(granuleID_list)` to see the result"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now we have a list of all the granule IDs for granules in the Landsat 8 collection that fall within the bounding box for the country Peru within `granuleID_list`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
-     Added an ipython notebook example that highlights searching for and compiling a list of granule IDs for batch processing

-    Within index.rst, added the searching for and compiling a list of granule IDs for batch processing notebook to the contents tree

