### PR TITLE
Second update for query_data_python.ipynb to include example for `whe…

### DIFF
--- a/docs/source/query/query_data_python.ipynb
+++ b/docs/source/query/query_data_python.ipynb
@@ -324,20 +324,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-<<<<<<< Updated upstream
-    "In the output of the previous example, we can see that the field `\"species\"` has the value `\"Maprounea membranacea\"`. Let's say we are interested in finding observations for the `\"gabon_mondah\"` project within the same bounding box as the previous example which have the species `\"Aucoumea klaineana\"` or `\"Coelocaryon sp.\"`. We can do this using `where`, a dictionary-like object which maps fields to required values within a query. To help demonstrate how to use `where`, we can create a function (in this example named `species_query`) which utilizes the `executeQuery()` function and prints the number of results as well as the first result. We will have the function accept arguments for the `query` object and `timeout`. `timeout` indicates the maximum number of seconds to wait for a response. Note that `timeout` has a default value of '180' and requires that the `poll_results` parameter be `True`. Depending on the request, it may be necessary to modify the timeout to make sure the server has enough time to process the request."
-=======
     "In the output of the previous example, we can see that the field `\"species\"` has the value `\"Maprounea membranacea\"`. Let's say we are interested in finding observations for the `\"gabon_mondah\"` project within the same bounding box as the previous example which have the species `\"Aucoumea klaineana\"` or `\"Coelocaryon sp.\"`. We can do this using `where`, a dictionary-like object which maps fields to required values within a query. To help demonstrate how to use `where`, we can create a function (in this example named `species_query`) which utilizes the `executeQuery()` function and prints the number of results as well as the first result."
->>>>>>> Stashed changes
    ]
   },
   {
    "cell_type": "code",
-<<<<<<< Updated upstream
-   "execution_count": 7,
-=======
    "execution_count": 6,
->>>>>>> Stashed changes
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,11 +385,7 @@
   },
   {
    "cell_type": "code",
-<<<<<<< Updated upstream
-   "execution_count": 8,
-=======
    "execution_count": 7,
->>>>>>> Stashed changes
    "metadata": {},
    "outputs": [
     {
@@ -431,11 +419,7 @@
   },
   {
    "cell_type": "code",
-<<<<<<< Updated upstream
-   "execution_count": 9,
-=======
    "execution_count": 8,
->>>>>>> Stashed changes
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
…re` query

query_data_python.ipynb has been updated to include example query with multiple parameters using where.