### PR TITLE
Test gitlab trigger

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -7,12 +7,14 @@ name: Trigger GitLab CI
 on:
   push:
     branches:
+      - master
+      - develop
       - ab/trigger-gitlab-tests
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
-  build:
+  trigger-build:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -13,8 +13,8 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  # This workflow contains a single job called "build"
-  trigger-build:
+  # This workflow contains a single job called "trigger-gitlab-pipeline"
+  trigger-gitlab-pipeline:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
 

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -1,0 +1,39 @@
+# This is a basic workflow to help you get started with Actions
+
+name: Trigger GitLab CI
+
+# Controls when the action will run. Triggers the workflow on push or pull request
+# events but only for the master branch
+on:
+  push:
+#     branches:
+#       - ab/trigger-gitlab-tests
+#     tags:
+#       - v*
+#       - stable
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+    - uses: actions/checkout@v2
+
+    # Runs a set of commands using the runners shell
+    - name: Trigger GitLab CI
+      env:
+        GITLAB_CI_TRIGGER_URL: ${{ secrets.GITLAB_CI_TRIGGER_URL }}
+        GITLAB_CI_TRIGGER_TOKEN: ${{ secrets.GITLAB_CI_TRIGGER_TOKEN }}
+      run: |
+        echo Running on ref ${GITHUB_REF##*/}
+        echo Trigger CI pipeline
+        curl -X POST \
+           -F token=${GITLAB_CI_TRIGGER_TOKEN} \
+           -F "ref=master" \
+           -F "variables[GITHUB_REF]=${GITHUB_REF##*/}" \
+           ${GITLAB_CI_TRIGGER_URL}

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -9,7 +9,7 @@ on:
     branches:
       - master
       - develop
-      - ab/trigger-gitlab-tests
+      - test-gitlab-trigger
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -6,11 +6,8 @@ name: Trigger GitLab CI
 # events but only for the master branch
 on:
   push:
-#     branches:
-#       - ab/trigger-gitlab-tests
-#     tags:
-#       - v*
-#       - stable
+    branches:
+      - ab/trigger-gitlab-tests
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
Borrowed (heavily) from how https://github.com/MAAP-Project/maap-jupyter-ide is configured to trigger gitlab pipelines.

This now triggers a pipeline in gitlab and the gitlab project is also updated to run tests on whatever branch is passed as `GITHUB_REF`.

WARNING: This passes github CI just if the request to run the pipeline in gitlab succeeds. If the pipeline itself fails, that gitlab pipeline failure will not show up as an ❌ here. For now I think that's ok but might be worth looking into later.
