### PR TITLE
Trigger the tests on PRs before merge

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -7,9 +7,11 @@ name: Trigger GitLab CI
 on:
   push:
     branches:
+      - test-gitlab-trigger
+  pull_request:
+    branches:
       - master
       - develop
-      - test-gitlab-trigger
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
This changes the tests to run on creation of pull requests to the `master` or `develop` branches.
TODO: if the test fails, report back to the PR.

Not 100% sure the `GITHUB_REF##` will be the PR...