### PR TITLE
Update trigger-gitlab.yml

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -25,6 +25,14 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
 
+    - name: Extract branch name
+      shell: bash
+      # $GITHUB_HEAD_REF is the source branch name
+      # $GITHUB_BASE_REF is the PR destination branch
+      # If we want to test that tests pass on the destination branch (e.g. master and develop) after merge, we probably want to add `master` and `develop` to the list of branches to run the CI on `push` and not just `pull_request`
+      run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/})"
+      id: extract_branch
+
     # Runs a set of commands using the runners shell
     - name: Trigger GitLab CI
       env:
@@ -36,5 +44,5 @@ jobs:
         curl -X POST \
            -F token=${GITLAB_CI_TRIGGER_TOKEN} \
            -F "ref=master" \
-           -F "variables[GITHUB_REF]=${GITHUB_REF##*/}" \
+           -F "variables[GITHUB_REF]=${{ steps.extract_branch.outputs.branch }}" \
            ${GITLAB_CI_TRIGGER_URL}


### PR DESCRIPTION
maap-tests workflows were failing because workflows triggered by PRs have a `GITHUB_REF` of `merge`, see https://mas.maap-project.org/root/maap-tests/-/jobs/2582, specifically this output:

```
$ docker build --build-arg GITHUB_REF=$GITHUB_REF --no-cache -t maap-tests .
Step 1/8 : FROM mas.maap-project.org:5000/root/jupyter_image/vanilla:stable
 ---> 8c310e2edfc8
Step 2/8 : ARG GITHUB_REF
 ---> Running in a9e7e056332f
Removing intermediate container a9e7e056332f
 ---> e8eedb5ac579
Step 3/8 : RUN git clone --branch $GITHUB_REF https://github.com/MAAP-Project/maap-documentation
 ---> Running in f48ca279e219
Cloning into 'maap-documentation'...
fatal: Remote branch merge not found in upstream origin
The command '/bin/sh -c git clone --branch $GITHUB_REF https://github.com/MAAP-Project/maap-documentation' returned a non-zero code: 128
```

This PR updates the `GITHUB_REF` used to build the maap-documentation code is the PR being opened against develop or master, e.g. the `GITHUB_HEAD_REF`