### PR TITLE
External data access revisions

### DIFF
--- a/docs/source/access/accessing_external_data.ipynb
+++ b/docs/source/access/accessing_external_data.ipynb
@@ -2,8 +2,6 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "29ab5482",
-   "metadata": {},
    "source": [
     "## Accessing External Granule Data\n",
     "\n",
@@ -13,113 +11,89 @@
     "\n",
     "![Create Jupyter Workspace](../_static/create_jupyter_workspace.png)\n",
     "\n",
-    "Alternatively, you can create a workspace using the \"Workspaces\" interface. See [Create Workspace](https://docs.maap-project.org/en/latest/platform_technical_documentation/create_workspace.html) for more information.\n",
-    "\n",
-    "\n",
-    "Optionally, you can check if your workspace is configured correctly by navigating to the side panel tab `Workspaces` and selecting the workspace's settings page via the 'Configure Workspace' button:\n",
-    "\n",
-    "![Configure Workspace](../_static/configure_workspace.png)\n",
-    "\n",
-    "Check that the container name is `mas.maap-project.org:5000/root/jupyter-image/vanilla:edl-federated-login`:\n",
-    "\n",
-    "```\n",
-    "            containers: \n",
-    "              - name: jupyter\n",
-    "                image: 'mas.maap-project.org:5000/root/jupyter-image/vanilla:develop'\n",
-    "```\n",
-    "\n",
-    "Click `SAVE` and then click `APPLY`. You are now ready to launch a Jupyter Notebook and access external granule data."
-   ]
+    "Alternatively, you can create a workspace using the \"Workspaces\" interface. See [Create Workspace](https://docs.maap-project.org/en/latest/platform_technical_documentation/create_workspace.html) for more information."
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "e5722a54",
-   "metadata": {},
    "source": [
     "# Accessing data from Jupyter Notebooks in your workspace\n",
     "\n",
     "Within your Jupyter Notebook, start by importing the `maap` package. Then invoke the MAAP, setting the `maap_host` argument to `api.ops.maap-project.org`."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "a424e70c",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# import the maap package to handle queries\n",
     "from maap.maap import MAAP\n",
     "# invoke the MAAP using the MAAP host argument\n",
     "maap = MAAP(maap_host='api.ops.maap-project.org')"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "a84dde34",
-   "metadata": {},
    "source": [
     "### Accessing Sentinel-1 Granule Data from the Alaska Satellite Facility (ASF)\n",
     "\n",
     "Search for a granule using the `searchGranule` function (for more information on searching for granules, see [Searching for Granules in MAAP](https://docs.maap-project.org/en/latest/search/granules.html)). Then utilize the `getData` function, which downloads granule data if it doesn't already exist locally. We can use `getData` to download the first result from our granule search into the file system and assign it to a variable (in this case `download`)."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "0517a16d",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# search for granule data using the collection concept ID argument \n",
     "results = maap.searchGranule(collection_concept_id='C1200231010-NASA_MAAP')\n",
     "# download first result\n",
     "download = results[0].getData()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "dc5aaed8",
-   "metadata": {},
    "source": [
     "We can then use the `print` function to see the file name and directory."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e090bed6",
-   "metadata": {},
+   "source": [
+    "# print file directory\n",
+    "print(download)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "./S1A_S3_GRDH_1SDH_20140615T034444_20140615T034512_001055_00107C_8977.zip\n"
      ]
     }
    ],
-   "source": [
-    "# print file directory\n",
-    "print(download)"
-   ]
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "551d00b0",
-   "metadata": {},
    "source": [
     "### Accessing Global Ecosystem Dynamics Investigation (GEDI) Level 3 Granule Data from the Oak Ridge National Lab (ORNL)\n",
     "\n",
     "We use a similar approach in order to access GEDI Level 3 granule data. Note that we can use `searchGranule`'s `cmr_host` argument to specify a CMR instance external to MAAP."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "a88d7d3a",
-   "metadata": {},
-   "outputs": [],
    "source": [
     "# search for granule data using CMR host name, collection concept ID, and Granule UR arguments\n",
     "results = maap.searchGranule(\n",
@@ -128,34 +102,34 @@
     "    granule_ur='GEDI_L3_Land_Surface_Metrics.GEDI03_elev_lowestmode_stddev_2019108_2020106_001_08.tif')\n",
     "# download first result\n",
     "download_2 = results[0].getData()"
-   ]
+   ],
+   "outputs": [],
+   "metadata": {}
   },
   {
    "cell_type": "markdown",
-   "id": "be6b062f",
-   "metadata": {},
    "source": [
     "As in the previous example, we can use the `print` function to see the file name and directory."
-   ]
+   ],
+   "metadata": {}
   },
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "434f7b7c",
-   "metadata": {},
+   "source": [
+    "# print file directory\n",
+    "print(download_2)"
+   ],
    "outputs": [
     {
-     "name": "stdout",
      "output_type": "stream",
+     "name": "stdout",
      "text": [
       "./GEDI03_elev_lowestmode_stddev_2019108_2020106_001_08.tif\n"
      ]
     }
    ],
-   "source": [
-    "# print file directory\n",
-    "print(download_2)"
-   ]
+   "metadata": {}
   }
  ],
  "metadata": {

--- a/docs/source/access/accessing_external_data.ipynb
+++ b/docs/source/access/accessing_external_data.ipynb
@@ -39,6 +39,17 @@
   {
    "cell_type": "markdown",
    "source": [
+    "### External data access application approval\n",
+    "\n",
+    "In order to access external DAAC data from the ADE, MAAP uses your Earthdata Login profile to send a data request to the desired DAAC application. For an example on how to grant access to an external DAAC, see [this example](https://disc.gsfc.nasa.gov/earthdata-login) on granting access to Goddard Earth Sciences Data and Information Services Center (GES DISC) from your Earthdata Login profile.\n",
+    "\n",
+    "If Earthdata Login access is not granted to your target DAAC application, the following examples will result in a 401 permission error."
+   ],
+   "metadata": {}
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
     "### Accessing Sentinel-1 Granule Data from the Alaska Satellite Facility (ASF)\n",
     "\n",
     "Search for a granule using the `searchGranule` function (for more information on searching for granules, see [Searching for Granules in MAAP](https://docs.maap-project.org/en/latest/search/granules.html)). Then utilize the `getData` function, which downloads granule data if it doesn't already exist locally. We can use `getData` to download the first result from our granule search into the file system and assign it to a variable (in this case `download`)."


### PR DESCRIPTION
This PR adds language clarifying the EDL application approval requirement for external data access.

In addition, the edl-federated-login image has been merged into the stable maap-jupyter-ide channel, so we need to remove this guidance from the documentation.