### PR TITLE
Update GEDI L3 collection identifier

### DIFF
--- a/docs/source/access/accessing_external_data.ipynb
+++ b/docs/source/access/accessing_external_data.ipynb
@@ -109,8 +109,7 @@
     "# search for granule data using CMR host name, collection concept ID, and Granule UR arguments\n",
     "results = maap.searchGranule(\n",
     "    cmr_host='cmr.earthdata.nasa.gov',\n",
-    "    collection_concept_id='C2067521974-ORNL_CLOUD',\n",
-    "    granule_ur='GEDI_L3_Land_Surface_Metrics.GEDI03_elev_lowestmode_stddev_2019108_2020106_001_08.tif')\n",
+    "    short_name='GEDI_L3_LandSurface_Metrics_V2_1952')
     "# download first result\n",
     "download_2 = results[0].getData()"
    ],

--- a/docs/source/access/accessing_external_data.ipynb
+++ b/docs/source/access/accessing_external_data.ipynb
@@ -109,7 +109,7 @@
     "# search for granule data using CMR host name, collection concept ID, and Granule UR arguments\n",
     "results = maap.searchGranule(\n",
     "    cmr_host='cmr.earthdata.nasa.gov',\n",
-    "    short_name='GEDI_L3_LandSurface_Metrics_V2_1952')
+    "    short_name='GEDI_L3_LandSurface_Metrics_V2_1952')",
     "# download first result\n",
     "download_2 = results[0].getData()"
    ],

--- a/docs/source/access/accessing_external_data.ipynb
+++ b/docs/source/access/accessing_external_data.ipynb
@@ -109,7 +109,7 @@
     "# search for granule data using CMR host name, collection concept ID, and Granule UR arguments\n",
     "results = maap.searchGranule(\n",
     "    cmr_host='cmr.earthdata.nasa.gov',\n",
-    "    short_name='GEDI_L3_LandSurface_Metrics_V2_1952')",
+    "    short_name='GEDI_L3_LandSurface_Metrics_V2_1952'),\n",
     "# download first result\n",
     "download_2 = results[0].getData()"
    ],


### PR DESCRIPTION
The code to access GEDI L3 data fails as-is because the concept id is no longer active (from what I can tell)

I executed the updated code in ade.ops and it works as expected
![Screen Shot 2022-04-04 at 4 14 57 PM](https://user-images.githubusercontent.com/15016780/161647808-b9f9cf3c-fc8f-4059-a289-011853c81b4f.png)

 except that I think it's downloading the data from ORNL DAAC and not earthdata cloud S3 location

![Screen Shot 2022-04-04 at 4 18 14 PM](https://user-images.githubusercontent.com/15016780/161647872-6b0422ea-350e-495d-8a3f-1c5928cc1ca1.png)

so this code should be updated so _location will be the S3 URL if it exists in the metadata

https://github.com/MAAP-Project/maap-py/blob/87efa1ea31098bc9cc43bbf04d3ddf2388caf7d2/maap/Result.py#L22

but will open a maap-py ticket for that