### PR TITLE
Update trigger-gitlab.yml

### DIFF
--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -8,6 +8,8 @@ on:
   push:
     branches:
       - test-gitlab-trigger
+      - master
+      - develop
   pull_request:
     branches:
       - master
@@ -30,7 +32,7 @@ jobs:
       # $GITHUB_HEAD_REF is the source branch name
       # $GITHUB_BASE_REF is the PR destination branch
       # If we want to test that tests pass on the destination branch (e.g. master and develop) after merge, we probably want to add `master` and `develop` to the list of branches to run the CI on `push` and not just `pull_request`
-      run: echo "##[set-output name=branch;]$(echo ${GITHUB_HEAD_REF#refs/heads/})"
+      run: echo "##[{name}={branch} >> $GITHUB_OUTPUT;]$(echo ${GITHUB_HEAD_REF#refs/heads/})"
       id: extract_branch
 
     # Runs a set of commands using the runners shell

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -32,7 +32,7 @@ jobs:
       # $GITHUB_HEAD_REF is the source branch name
       # $GITHUB_BASE_REF is the PR destination branch
       # If we want to test that tests pass on the destination branch (e.g. master and develop) after merge, we probably want to add `master` and `develop` to the list of branches to run the CI on `push` and not just `pull_request`
-      run: echo "##[{name}={branch} >> $GITHUB_OUTPUT;]$(echo ${GITHUB_HEAD_REF#refs/heads/})"
+      run: echo "{name}={value}" >> $GITHUB_OUTPUT
       id: extract_branch
 
     # Runs a set of commands using the runners shell

--- a/.github/workflows/trigger-gitlab.yml
+++ b/.github/workflows/trigger-gitlab.yml
@@ -32,7 +32,7 @@ jobs:
       # $GITHUB_HEAD_REF is the source branch name
       # $GITHUB_BASE_REF is the PR destination branch
       # If we want to test that tests pass on the destination branch (e.g. master and develop) after merge, we probably want to add `master` and `develop` to the list of branches to run the CI on `push` and not just `pull_request`
-      run: echo "{name}={value}" >> $GITHUB_OUTPUT
+      run: echo "{name}={branch}" >> $GITHUB_OUTPUT
       id: extract_branch
 
     # Runs a set of commands using the runners shell


### PR DESCRIPTION
Updated yml file to run job after pushes to the develop or master branch.
There was a syntax error with set-output. I do not see the error when pushing to the test-gitlab-trigger branch after updating the syntax.