### PR TITLE
Stac

### DIFF
--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -3,8 +3,8 @@ MAAP's Dual Catalog
 
 MAAP users are advised to use two catalogs:
 
-1. Use NASA's Operational CMR to discover NASA-produced and curated data: https://cmr.earthdata.nasa.gov
-2. Use MAAP STAC for data not found in NASA CMR, and data produced by MAAP users: https://stac.maap-project.org
+1. Use NASA's Operational CMR to discover NASA-produced and curated data: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html.
+2. Use MAAP STAC for data not found in NASA CMR, and data produced by MAAP users: https://stac.maap-project.org/docs.
 
 The https://cmr.maap-project.org catalog will be deprecated by **May 1, 2023**. Users should request collections they need from this catalog to be made discoverable in the MAAP STAC or NASA's Operational CMR if they're not already there.
 

--- a/docs/source/technical_tutorials/searching.rst
+++ b/docs/source/technical_tutorials/searching.rst
@@ -4,8 +4,8 @@ Search
 
 MAAP users are advised to use two catalogs:
 
-1. Use NASA's Operational CMR to discover NASA-produced and curated data: https://cmr.earthdata.nasa.gov
-2. Use MAAP STAC for data not found in NASA CMR, and data produced by MAAP users: https://stac.maap-project.org
+1. Use NASA's Operational CMR to discover NASA-produced and curated data: https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html.
+2. Use MAAP STAC for data not found in NASA CMR, and data produced by MAAP users: https://stac.maap-project.org/docs.
 
 The https://cmr.maap-project.org catalog will be deprecated by **May 1, 2023**. Users should request collections they need from this catalog to be made discoverable in the MAAP STAC or NASA's Operational CMR if they're not already there.
 

--- a/docs/source/technical_tutorials/searching.rst
+++ b/docs/source/technical_tutorials/searching.rst
@@ -16,7 +16,7 @@ More information on each catalog and migrating from MAAP's CMR here: `MAAP's Dua
   :caption: Search Topics:
   
   search/catalog.rst
-  search/searching_edsc_gui
+  search/searching_edsc_gui.ipynb
   search/collections.ipynb
   search/granules.ipynb
   search/searching_compiling_list_of_granule_ids.ipynb

--- a/docs/source/technical_tutorials/searching.rst
+++ b/docs/source/technical_tutorials/searching.rst
@@ -9,7 +9,7 @@ MAAP users are advised to use two catalogs:
 
 The https://cmr.maap-project.org catalog will be deprecated by **May 1, 2023**. Users should request collections they need from this catalog to be made discoverable in the MAAP STAC or NASA's Operational CMR if they're not already there.
 
-More information on each catalog and migrating from MAAP's CMR here: `MAAP's Dual Catalog </search/catalog.html>`_. 
+More information on each catalog and migrating from MAAP's CMR here: `MAAP's Dual Catalog <search/catalog.html>`_. 
 
 .. toctree::
   :maxdepth: 2


### PR DESCRIPTION
A few more minor changes:
* fix relative link
* add missing `ipynb` suffix for EDSC page
* For both catalogs, link to the API docs.