### PR TITLE
removed cmr and ops from technical tutorials, copied to new branch

### DIFF
--- a/docs/source/technical_tutorials/access/accessing_data.ipynb
+++ b/docs/source/technical_tutorials/access/accessing_data.ipynb
@@ -169,7 +169,7 @@
     "from rasterio.session import AWSSession\n",
     "\n",
     "\n",
-    "maap = MAAP(maap_host='api.ops.maap-project.org')\n",
+    "maap = MAAP(maap_host='api.maap-project.org')n/a\n",
     "credentials = maap.aws.requester_pays_credentials()\n",
     "\n",
     "boto3_session = boto3.Session(\n",

--- a/docs/source/technical_tutorials/access/accessing_external_data.ipynb
+++ b/docs/source/technical_tutorials/access/accessing_external_data.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "3bb79280",
+   "id": "517b7f6b",
    "metadata": {},
    "source": [
     "## Accessing data provided by NASA's Distributed Active Archive Centers (DAACs)"
@@ -10,10 +10,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "857d06d6",
+   "id": "9653fb73",
    "metadata": {},
    "source": [
-    "It is possible to download data provided by [DAACs](https://www.earthdata.nasa.gov/eosdis/daacs), including data which is not cataloged by the MAAP's CMR, using the [NASA MAAP ADE](https://ade.ops.maap-project.org/). This data is hosted externally from the MAAP but can be accessed using the NASA MAAP ADE's authentication systems.\n",
+    "It is possible to download data provided by [DAACs](https://www.earthdata.nasa.gov/eosdis/daacs), including data which is not cataloged by the MAAP's CMR, using the [NASA MAAP ADE](https://ade.maap-project.org/). This data is hosted externally from the MAAP but can be accessed using the NASA MAAP ADE's authentication systems.\n",
     "\n",
     "In order to do this, we start by creating a Jupyter workspace within the NASA MAAP ADE. Using the left-hand navigation, select \"+ Get Started\" and then select the \"Jupyter - MAAP Basic Stable\" workspace.\n",
     "\n",
@@ -24,7 +24,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca9e80e0",
+   "id": "068fa0b2",
    "metadata": {},
    "source": [
     "### Accessing data from Jupyter Notebooks in your workspace"
@@ -32,37 +32,36 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22c00f9b",
+   "id": "c8b3078d",
    "metadata": {},
    "source": [
-    "Within your Jupyter Notebook, start by importing the `maap` package. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.ops.maap-project.org'`."
+    "Within your Jupyter Notebook, start by importing the `maap` package. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.maap-project.org'`."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "47ee4a37",
+   "id": "f55894a4",
    "metadata": {},
    "outputs": [],
    "source": [
     "# import the maap package\n",
     "from maap.maap import MAAP\n",
     "# invoke the MAAP constructor using the maap_host argument\n",
-    "maap = MAAP(maap_host='api.ops.maap-project.org')"
+    "maap = MAAP(maap_host='api.maap-project.org')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "c7b5f903",
+   "id": "941d5a5d",
    "metadata": {},
    "source": [
     "### Granting Earthdata Login access to your target DAAC application"
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
-   "id": "1c508114",
+   "id": "c902967e",
    "metadata": {},
    "source": [
     "In order to access external DAAC data from the NASA MAAP ADE, MAAP uses your Earthdata Login profile to send a data request to the desired DAAC application. \n",
@@ -96,7 +95,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72b2b987",
+   "id": "c213f017",
    "metadata": {},
    "source": [
     "### Accessing Sentinel-1 Granule Data from the Alaska Satellite Facility (ASF)"
@@ -104,7 +103,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef0390b0",
+   "id": "aa06e841",
    "metadata": {},
    "source": [
     "Search for a granule using the `searchGranule` function (for more information on searching for granules, see [Searching for Granules in MAAP](https://docs.maap-project.org/en/latest/search/granules.html)). Then utilize the `getData` function, which downloads granule data if it doesn't already exist locally. We can use `getData` to download the first result from our granule search into the file system and assign it to a variable (in this case `download`). Note that you will need to authorize the 'Alaska Satellite Facility Data Access' application before downloading any results from our search (see the above section for more information concerning authorizing applications)."
@@ -113,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "6378e8de",
+   "id": "6ef25434",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b871373f",
+   "id": "83b7514d",
    "metadata": {},
    "source": [
     "Note that we can then use the `print` function to see the file name and directory."
@@ -134,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "e831ede2",
+   "id": "22a45f12",
    "metadata": {},
    "outputs": [
     {
@@ -152,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "abfe4af6",
+   "id": "a959c407",
    "metadata": {},
    "source": [
     "### Accessing Harmonized Landsat Sentinel-2 (HLS) Level 3 Granule Data from the Land Processes Distributed Active Archive Center (LP DAAC)\n",
@@ -163,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "924c0b46",
+   "id": "005ba0c2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +176,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef64180f",
+   "id": "7995172a",
    "metadata": {},
    "source": [
     "As in the previous example, we can use the `print` function to see the file name and directory."
@@ -186,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "e08ce66e",
+   "id": "fc1c455b",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/technical_tutorials/access/accessing_gedi_l3_data.ipynb
+++ b/docs/source/technical_tutorials/access/accessing_gedi_l3_data.ipynb
@@ -2,20 +2,20 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2852ea6a",
+   "id": "04ae0304",
    "metadata": {},
    "source": [
     "## Accessing Global Ecosystem Dynamics Investigation (GEDI) Level 3 Granule Data\n",
     "\n",
     "In this example, we demonstrate how to access GEDI Level 3 granule data on the MAAP ADE.\n",
     "\n",
-    "Within your Jupyter Notebook, start by importing the `maap` package. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.ops.maap-project.org'`."
+    "Within your Jupyter Notebook, start by importing the `maap` package. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.maap-project.org'`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "65ed6944",
+   "execution_count": 8,
+   "id": "01faea33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,34 +24,34 @@
     "# import the maap package to handle queries\n",
     "from maap.maap import MAAP\n",
     "# invoke the MAAP constructor using the maap_host argument\n",
-    "maap = MAAP(maap_host='api.ops.maap-project.org')"
+    "maap = MAAP(maap_host='api.maap-project.org')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "5957f899",
+   "id": "4ab93e08",
    "metadata": {},
    "source": [
-    "Search for a granule using the `searchGranule` function (for more information on searching for granules, see [Searching for Granules in MAAP](https://docs.maap-project.org/en/latest/search/granules.html)). Note that we can use `searchGranule`'s `cmr_host` argument to specify `cmr.maap-project.org` as the CMR instance. "
+    "Search for a granule using the `searchGranule` function (for more information on searching for granules, see [Searching for Granules in MAAP](https://docs.maap-project.org/en/latest/search/granules.html)). Note that we can use `searchGranule`'s `cmr_host` argument to specify `cmr.earthdata.nasa.gov` as the CMR instance. "
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "bb76be55",
+   "execution_count": 3,
+   "id": "2a2b7a34",
    "metadata": {},
    "outputs": [],
    "source": [
     "# search for granule data using CMR host name and collection concept ID arguments\n",
     "results = maap.searchGranule(\n",
-    "    cmr_host='cmr.maap-project.org',\n",
-    "    collection_concept_id='C1201702030-NASA_MAAP'\n",
+    "    cmr_host='cmr.earthdata.nasa.gov',\n",
+    "    collection_concept_id='C2153683336-ORNL_CLOUD'\n",
     ")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2d08b82b",
+   "id": "af72ac45",
    "metadata": {},
    "source": [
     "Let's view the list of `GranuleUR`s within our `results`:"
@@ -59,31 +59,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "02acc4b5",
+   "execution_count": 4,
+   "id": "a140c212",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "['GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_stddev_2019108_2020287_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_counts_2019108_2021104_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_stddev_2019108_2021104_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_mean_2019108_2020287_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_mean_2019108_2021104_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_stddev_2019108_2021104_002_02.tif',\n",
        " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_counts_2019108_2020287_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_mean_2019108_2021104_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_counts_2019108_2021104_002_02.tif',\n",
        " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_mean_2019108_2020287_002_02.tif',\n",
        " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_stddev_2019108_2020287_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_counts_2019108_2021216_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_mean_2019108_2021216_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_stddev_2019108_2021104_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_stddev_2019108_2021104_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_mean_2019108_2020287_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_mean_2019108_2021104_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_mean_2019108_2021104_002_02.tif',\n",
        " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_stddev_2019108_2021216_002_02.tif',\n",
        " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_mean_2019108_2021216_002_02.tif',\n",
-       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_stddev_2019108_2021216_002_02.tif']"
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_stddev_2019108_2021216_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_mean_2019108_2021216_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_counts_2019108_2021216_002_02.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_mean_2019108_2022019_002_03.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_counts_2019108_2022019_002_03.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_mean_2019108_2022019_002_03.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_stddev_2019108_2022019_002_03.tif',\n",
+       " 'GEDI_L3_LandSurface_Metrics_V2.GEDI03_rh100_stddev_2019108_2022019_002_03.tif']"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -95,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e777c700",
+   "id": "7102c2b2",
    "metadata": {},
    "source": [
     "For this example, we are interested in downloading `GEDI03_elev_lowestmode_stddev_2019108_2021104_002_02.tif`."
@@ -103,8 +108,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
-   "id": "18ab7e6a",
+   "execution_count": 9,
+   "id": "f5911308",
    "metadata": {},
    "outputs": [
     {
@@ -113,19 +118,19 @@
        "'GEDI_L3_LandSurface_Metrics_V2.GEDI03_elev_lowestmode_stddev_2019108_2021104_002_02.tif'"
       ]
      },
-     "execution_count": 4,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "# select item\n",
-    "results[2]['Granule']['GranuleUR']"
+    "results[5]['Granule']['GranuleUR']"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "332503ca",
+   "id": "669d87d7",
    "metadata": {},
    "source": [
     "Now utilize the `getData` function, which downloads granule data if it doesn't already exist locally. We can use `getData` to download the third result from our granule search into the file system and assign its local path to a variable (in this case `download`)."
@@ -133,20 +138,20 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
-   "id": "39e575aa",
+   "execution_count": 12,
+   "id": "8bae223d",
    "metadata": {},
    "outputs": [],
    "source": [
     "# download granule item\n",
     "local_dir = '/projects/local_data'  # download directory (absolute path or relative to current directory)\n",
     "os.makedirs(local_dir, exist_ok=True) # create directories, as necessary\n",
-    "download = results[2].getData(local_dir)  # default download directory is current directory, if no directory is given"
+    "download = results[5].getData(local_dir)  # default download directory is current directory, if no directory is given"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "65d960ba",
+   "id": "544d8587",
    "metadata": {},
    "source": [
     "We can then use the `print` function to see the file name and directory."
@@ -154,8 +159,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "id": "ccdfc922",
+   "execution_count": 13,
+   "id": "0b37aa45",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/technical_tutorials/access/accessing_gedi_l4a_data.ipynb
+++ b/docs/source/technical_tutorials/access/accessing_gedi_l4a_data.ipynb
@@ -2,20 +2,20 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "2e8d6183",
+   "id": "5b3b27fe",
    "metadata": {},
    "source": [
     "## Accessing Global Ecosystem Dynamics Investigation (GEDI) Level 4A Granule Data\n",
     "\n",
     "In this example, we demonstrate how to access GEDI Level 4A granule data on the MAAP ADE.\n",
     "\n",
-    "Within your Jupyter Notebook, start by importing the `maap` package. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.ops.maap-project.org'`."
+    "Within your Jupyter Notebook, start by importing the `maap` package. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.maap-project.org'`."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "id": "2f250d6c",
+   "execution_count": 7,
+   "id": "34d5748a",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -24,28 +24,28 @@
     "# import the maap package to handle queries\n",
     "from maap.maap import MAAP\n",
     "# invoke the MAAP constructor using the maap_host argument\n",
-    "maap = MAAP(maap_host='api.ops.maap-project.org')"
+    "maap = MAAP(maap_host='api.maap-project.org')"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "f6342077",
+   "id": "0348dcff",
    "metadata": {},
    "source": [
-    "Search for a granule using the `searchGranule` function (for more information on searching for granules, see [Searching for Granules in MAAP](https://docs.maap-project.org/en/latest/search/granules.html)). Note that we can use `searchGranule`'s `cmr_host` argument to specify `cmr.maap-project.org` as the CMR instance. Then utilize the `getData` function, which downloads granule data if it doesn't already exist locally. We can use `getData` to download the first result from our granule search into the file system and assign its local path to a variable (in this case `download`)."
+    "Search for a granule using the `searchGranule` function (for more information on searching for granules, see [Searching for Granules in MAAP](https://docs.maap-project.org/en/latest/search/granules.html)). Note that we can use `searchGranule`'s `cmr_host` argument to specify `cmr.earthdata.nasa.gov` as the CMR instance. Then utilize the `getData` function, which downloads granule data if it doesn't already exist locally. We can use `getData` to download the first result from our granule search into the file system and assign its local path to a variable (in this case `download`)."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
-   "id": "d1fbb45b",
+   "execution_count": 9,
+   "id": "16b471f4",
    "metadata": {},
    "outputs": [],
    "source": [
     "# search for granule data using CMR host name, collection concept ID, and Granule UR arguments\n",
     "results = maap.searchGranule(\n",
-    "    cmr_host='cmr.maap-project.org',\n",
-    "    collection_concept_id='C1202028193-NASA_MAAP',\n",
+    "    cmr_host='cmr.earthdata.nasa.gov',\n",
+    "    collection_concept_id='C2237824918-ORNL_CLOUD',\n",
     "    granule_ur='GEDI_L4A_AGB_Density_V2_1.GEDI04_A_2019107224731_O01958_01_T02638_02_002_02_V002.h5')\n",
     "# download first result\n",
     "local_dir = '/projects/local_data'  # Download directory (absolute path or relative to current directory)\n",
@@ -55,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73d354d9",
+   "id": "757dca1d",
    "metadata": {},
    "source": [
     "We can then use the `print` function to see the file name and directory."
@@ -63,8 +63,8 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
-   "id": "d71d4bcc",
+   "execution_count": 10,
+   "id": "88d326de",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/technical_tutorials/search/granules.ipynb
+++ b/docs/source/technical_tutorials/search/granules.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -14,7 +13,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We begin by importing the `maap` and `pprint` packages. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.ops.maap-project.org'`."
+    "We begin by importing the `maap` and `pprint` packages. Then invoke the `MAAP` constructor, setting the `maap_host` argument to `'api.maap-project.org'`."
    ]
   },
   {
@@ -30,7 +29,7 @@
     "from pprint import pprint\n",
     "\n",
     "# invoke the MAAP constructor using the maap_host argument\n",
-    "maap = MAAP(maap_host='api.ops.maap-project.org')"
+    "maap = MAAP(maap_host='api.maap-project.org')"
    ]
   },
   {

--- a/docs/source/technical_tutorials/user_data/create-datasets-for-dashboard.ipynb
+++ b/docs/source/technical_tutorials/user_data/create-datasets-for-dashboard.ipynb
@@ -1,7 +1,6 @@
 {
  "cells": [
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -30,7 +29,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -64,7 +62,7 @@
     "import urllib\n",
     "\n",
     "# create MAAP class\n",
-    "maap = MAAP(maap_host='api.ops.maap-project.org')"
+    "maap = MAAP(maap_host='api.maap-project.org')"
    ]
   },
   {
@@ -249,7 +247,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -275,7 +272,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -321,7 +317,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -401,7 +396,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -476,7 +470,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -489,7 +482,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -554,7 +546,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -582,7 +573,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -603,7 +593,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -644,7 +633,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -674,7 +662,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -700,7 +687,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -772,7 +758,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -788,7 +773,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -803,7 +787,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -831,7 +814,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -841,7 +823,6 @@
    ]
   },
   {
-   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/docs/source/technical_tutorials/visualization/ade_mosaic.ipynb
+++ b/docs/source/technical_tutorials/visualization/ade_mosaic.ipynb
@@ -207,7 +207,7 @@
     "Other parameters are possible, see https://titiler.maap-project.org/docs#/MosaicJSON/wmts_mosaicjson_WMTSCapabilities_xml_get\n",
     "\"\"\"\n",
     "\n",
-    "wmts_url = f\"https://titiler.ops.maap-project.org/mosaics/{mosaicid}/WMTSCapabilities.xml\"\n",
+    "wmts_url = f\"https://titiler.maap-project.org/mosaics/{mosaicid}/WMTSCapabilities.xml\"\n",
     "params = {\n",
     "    \"tile_format\":\"png\",\n",
     "    \"tile_scale\":\"1\",\n",

--- a/docs/source/technical_tutorials/visualization/interval_color_mapping.ipynb
+++ b/docs/source/technical_tutorials/visualization/interval_color_mapping.ipynb
@@ -3,7 +3,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "id": "065e7333",
+   "id": "429b6cdf",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   {
    "cell_type": "code",
    "execution_count": 2,
-   "id": "a3351f8a",
+   "id": "ee8173d9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -26,7 +26,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "105a6647",
+   "id": "41d15632",
    "metadata": {},
    "source": [
     "# Discover data from STAC"
@@ -35,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "id": "56ebeafa",
+   "id": "7a3524dc",
    "metadata": {},
    "outputs": [
     {
@@ -51,7 +51,7 @@
    ],
    "source": [
     "stac_endpoint = \"https://stac.maap-project.org\"\n",
-    "titiler_endpoint = \"https://titiler.ops.maap-project.org\"\n",
+    "titiler_endpoint = \"https://titiler.maap-project.org\"\n",
     "collection = \"AfriSAR_AGB_Maps_1681\"\n",
     "items_response = requests.get(f\"{stac_endpoint}/collections/{collection}/items\").json()\n",
     "url = items_response['features'][0]['assets']['data']['href']\n",
@@ -60,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed5dabc1",
+   "id": "edb1f9fd",
    "metadata": {},
    "source": [
     "# Get data values from the `/statistics` endpoint"
@@ -69,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "id": "ed316a27",
+   "id": "d303acb8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "id": "41cd4a74",
+   "id": "d9e4d649",
    "metadata": {},
    "outputs": [
     {
@@ -117,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd2ca7d7",
+   "id": "a47012f9",
    "metadata": {},
    "source": [
     "# Pick a color map and create a linear mapping"
@@ -126,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": 6,
-   "id": "afc86287",
+   "id": "62ae547f",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "id": "3d13d239",
+   "id": "9dd8fd84",
    "metadata": {},
    "outputs": [
     {
@@ -185,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "id": "e765ff57",
+   "id": "ebf03e23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +195,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59f176cb",
+   "id": "fbb3ab7d",
    "metadata": {},
    "source": [
     "# Preview the data"
@@ -204,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "id": "bae71713",
+   "id": "84670d92",
    "metadata": {},
    "outputs": [
     {

--- a/docs/source/technical_tutorials/visualization/using_pycmc.ipynb
+++ b/docs/source/technical_tutorials/visualization/using_pycmc.ipynb
@@ -89,7 +89,7 @@
    "outputs": [],
    "source": [
     "# visualize the available set of layers\n",
-    "w.load_layer_config(\"https://api.ops.maap-project.org/api/wmts/GetCapabilities\", \"wmts/xml\")"
+    "w.load_layer_config(\"https://api.maap-project.org/api/wmts/GetCapabilities\", \"wmts/xml\")"
    ]
   },
   {
@@ -120,7 +120,7 @@
    "outputs": [],
    "source": [
     "# visualize a single granule using the granule UR\n",
-    "w.load_layer_config(\"https://api.ops.maap-project.org/api/wmts/GetCapabilities?short_name=AFLVIS2&granule_ur=SC:AFLVIS2.001:138348905\", \"wmts/xml\")"
+    "w.load_layer_config(\"https://api.maap-project.org/api/wmts/GetCapabilities?short_name=AFLVIS2&granule_ur=SC:AFLVIS2.001:138348905\", \"wmts/xml\")"
    ]
   },
   {


### PR DESCRIPTION
I looked through all the files in technical tutorials and removed instances of MAAP CMR (didn't see any references to search.maap) and .ops from the links. From what I could tell, accessing_gedi_l3_data and accessing_gedi_l4a_data were the only two that had MAAP CMR, so I switched them to cmr.earthdata and adjusted the concept IDs. All other files changed should just have .ops removed. I also ignored srtm-stac-mosaic under "visualization" since that likely needs to be delisted for now.

Will go through the science tutorials next and have those pushed, but I wanted to go ahead and look for cmr/.ops in the other tutorials while we were focused on name changes in the science tutorials (sorry this took longer than I wanted to push, I had to hassle some with git).