### PR TITLE
catalog.rst link updates

### DIFF
--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -69,7 +69,7 @@ For all NASA MAAP users, access to NASA'S Operational data is provided via a fed
 
 Anyone can access data through Earthdata Login as well.
 
-Find more documentation about how to access data in CMR in the `Access </docs/source/technical_tutorials/access>`_ section of this documentation.
+Find more documentation about how to access data in CMR in the `Access </docs/source/technical_tutorials/accessing.html>`_ section of this documentation.
 
 =======================================
 Migrating from MAAP's CMR

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -69,7 +69,7 @@ For all NASA MAAP users, access to NASA'S Operational data is provided via a fed
 
 Anyone can access data through Earthdata Login as well.
 
-Find more documentation about how to access data in CMR in the `Access </docs/source/technical_tutorials/access>`_ section of this documentation.
+Find more documentation about how to access data in CMR in the `Access <../accessing.html>`_ section of this documentation.
 
 =======================================
 Migrating from MAAP's CMR

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -26,7 +26,7 @@ API documentation is available here: https://stac.maap-project.org/api.html (wil
 
 The general STAC API spec is here: https://api.stacspec.org/v1.0.0-rc.1/core/.
 
-An example of using pystac-client is included above and in `Searching STAC Documentation <docs/source/technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
+An example of using pystac-client is included above and in `Searching STAC Documentation <maap-documentation/docs/source/technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
 
 Data Access via STAC
 ---------------------------------------

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -26,7 +26,7 @@ API documentation is available here: https://stac.maap-project.org/api.html (wil
 
 The general STAC API spec is here: https://api.stacspec.org/v1.0.0-rc.1/core/.
 
-An example of using pystac-client is included above and in `Searching STAC Documentation <technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
+An example of using pystac-client is included above and in `Searching STAC Documentation <source/technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
 
 Data Access via STAC
 ---------------------------------------

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -26,7 +26,7 @@ API documentation is available here: https://stac.maap-project.org/api.html (wil
 
 The general STAC API spec is here: https://api.stacspec.org/v1.0.0-rc.1/core/.
 
-An example of using pystac-client is included above and in `Searching STAC Documentation <search/searching_the_stac_catalog.ipynb>`_.
+An example of using pystac-client is included above and in `Searching STAC Documentation <technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
 
 Data Access via STAC
 ---------------------------------------

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -60,7 +60,7 @@ CMR Discovery
 
 Users can discover data NASA's Operational CMR via its publicly accessible API: https://cmr.earthdata.nasa.gov and user interface: https://search.earthdata.nasa.gov.
 
-CMR Search documentation can be found in `Searching Collections <search/collections.ipynb>`_ and `Searching Granules <search/granules.ipynb>`_ and https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html.
+CMR Search documentation can be found in `Searching Collections <collections.ipynb>`_ and `Searching Granules <granules.ipynb>`_ and https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html.
 
 CMR Access
 ---------------------------------------
@@ -69,7 +69,7 @@ For all NASA MAAP users, access to NASA'S Operational data is provided via a fed
 
 Anyone can access data through Earthdata Login as well.
 
-Find more documentation about how to access data in CMR in the `Access <accessing.html>`_ section of this documentation.
+Find more documentation about how to access data in CMR in the `Access <access>`_ section of this documentation.
 
 =======================================
 Migrating from MAAP's CMR

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -26,7 +26,7 @@ API documentation is available here: https://stac.maap-project.org/api.html (wil
 
 The general STAC API spec is here: https://api.stacspec.org/v1.0.0-rc.1/core/.
 
-An example of using pystac-client is included above and in `Searching STAC Documentation <source/technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
+An example of using pystac-client is included above and in `Searching STAC Documentation <docs/source/technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
 
 Data Access via STAC
 ---------------------------------------

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -26,7 +26,7 @@ API documentation is available here: https://stac.maap-project.org/api.html (wil
 
 The general STAC API spec is here: https://api.stacspec.org/v1.0.0-rc.1/core/.
 
-An example of using pystac-client is included above and in `Searching STAC Documentation <maap-documentation/docs/source/technical_tutorials/search/searching_the_stac_catalog.ipynb>`_.
+An example of using pystac-client is included above and in `Searching STAC Documentation <searching_the_stac_catalog.ipynb>`_.
 
 Data Access via STAC
 ---------------------------------------

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -69,7 +69,7 @@ For all NASA MAAP users, access to NASA'S Operational data is provided via a fed
 
 Anyone can access data through Earthdata Login as well.
 
-Find more documentation about how to access data in CMR in the `Access <access>`_ section of this documentation.
+Find more documentation about how to access data in CMR in the `Access </technical_tutorials/access>`_ section of this documentation.
 
 =======================================
 Migrating from MAAP's CMR

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -69,7 +69,7 @@ For all NASA MAAP users, access to NASA'S Operational data is provided via a fed
 
 Anyone can access data through Earthdata Login as well.
 
-Find more documentation about how to access data in CMR in the `Access </technical_tutorials/access>`_ section of this documentation.
+Find more documentation about how to access data in CMR in the `Access </docs/source/technical_tutorials/access>`_ section of this documentation.
 
 =======================================
 Migrating from MAAP's CMR

--- a/docs/source/technical_tutorials/search/catalog.rst
+++ b/docs/source/technical_tutorials/search/catalog.rst
@@ -69,7 +69,7 @@ For all NASA MAAP users, access to NASA'S Operational data is provided via a fed
 
 Anyone can access data through Earthdata Login as well.
 
-Find more documentation about how to access data in CMR in the `Access </docs/source/technical_tutorials/accessing.html>`_ section of this documentation.
+Find more documentation about how to access data in CMR in the `Access </docs/source/technical_tutorials/access>`_ section of this documentation.
 
 =======================================
 Migrating from MAAP's CMR


### PR DESCRIPTION
Reference ticket: https://github.com/orgs/NASA-IMPACT/projects/29/views/6?pane=issue&itemId=29702274

Stac API link was previously updated for [this ticket](https://github.com/orgs/NASA-IMPACT/projects/29/views/6?pane=issue&itemId=29272491), but I also found other links that were broken, so this is a new PR to fix them. 

First or second commit will be testing links as they're linked like "Searching STAC Documentation <search/searching_the_stac_catalog.ipynb>", so I'm adjusting layers to see what works.