### PR TITLE
Update custom-environments.ipynb

### DIFF
--- a/docs/source/system_reference_guide/custom-environments.ipynb
+++ b/docs/source/system_reference_guide/custom-environments.ipynb
@@ -94,7 +94,7 @@
     "and to activate it : \n",
     "\n",
     "```\n",
-    "mamba activate env-example\n",
+    "conda activate env-example\n",
     "```\n",
     "\n",
     "### Updating an existing environment with a configuration file\n",


### PR DESCRIPTION
mamba will throw a confusing error if you try to use it to activate your environment. Conda does not.