### PR TITLE
add virtual envs patterns to gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build/
 .ipynb_checkpoints
 mosaic.json
 *.h5
+*venv/


### PR DESCRIPTION
Changes tracked by git in the virtual env I had for this repo were making VS code crashing on my computer. So I added these two lines so that anything like .venv, .docs_venv, ... is ignored. 