### PR TITLE
Creating COG writing and validation docs

### DIFF
--- a/docs/source/technical_tutorials/user_data.rst
+++ b/docs/source/technical_tutorials/user_data.rst
@@ -6,3 +6,5 @@ User Data
   :caption: User Data:
   
   user_data/create-datasets-for-dashboard.ipynb
+  user_data/COG-NonCOG-validation.ipynb
+  user_data/writing-COGs-with-Python.ipynb

--- a/docs/source/technical_tutorials/user_data/COG-NonCOG-validation.ipynb
+++ b/docs/source/technical_tutorials/user_data/COG-NonCOG-validation.ipynb
@@ -1,0 +1,486 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "01d7d4bd-b8c6-4c8a-a390-723cb491e667",
+   "metadata": {},
+   "source": [
+    "# COG vs Non-COG Validation\n",
+    "\n",
+    "Authors: Rajat Shinde (UAH), Sheyenne Kirkland (UAH), Alex Mandel (DevSeed), Jamison French (DevSeed), Brian Freitag (NASA MSFC)\n",
+    "\n",
+    "Date: January 29, 2024\n",
+    "\n",
+    "Description: In this tutorial, we will explore how to validate a Cloud-Optimized GeoTIFF (COG) vs Non-COG.\n",
+    "\n",
+    "### Note\n",
+    "If you are referring to this tutorial after following the [Writing Cloud-Optimized GeoTIFF (COG) with Python](maap-documentation/docs/source/technical_tutorials/user_data/writing-COGs-with-Python.ipynb), then you can directly start from the [Check if COG is a valid COG](maap-documentation/docs/source/technical_tutorials/user_data/COG-NonCOG-validation.ipynb#Check-if-COG-is-a-valid-COG) section.\n",
+    "\n",
+    "### Run This Notebook\n",
+    "To access and run this tutorial within MAAP's Algorithm Development Environment (ADE), please refer to the [\"Getting started with the MAAP\"](https://docs.maap-project.org/en/latest/getting_started/getting_started.html) section of our documentation.\n",
+    "\n",
+    "Disclaimer: It is highly recommended to run a tutorial within MAAP's ADE, which already includes packages specific to MAAP, such as maap-py. Running the tutorial outside of the MAAP ADE may lead to errors.\n",
+    "\n",
+    "### About The Dataset\n",
+    "\n",
+    "We will be using the Advanced Spaceborne Thermal Emission and Reflection Radiometer (ASTER) Level 1 Precision Terrain Corrected Registered At-Sensor Radiance (AST_L1T) data. This data contains calibrated at-sensor radiance, which corresponds with the ASTER Level 1B (AST_L1B) (https://doi.org/10.5067/ASTER/AST_L1B.003), that has been geometrically corrected, and rotated to a north-up UTM projection. The AST_L1T is created from a single resampling of the corresponding ASTER L1A (AST_L1A) (https://doi.org/10.5067/ASTER/AST_L1A.003) product. The bands available in the AST_L1T depend on the bands in the AST_L1A and can include up to three Visible and Near Infrared (VNIR) bands, six Shortwave Infrared (SWIR) bands, and five Thermal Infrared (TIR) bands. The AST_L1T dataset does not include the aft-looking VNIR band 3.\n",
+    "\n",
+    "The precision terrain correction process incorporates GLS2000 digital elevation data with derived ground control points (GCPs) to achieve topographic accuracy for all daytime scenes where correlation statistics reach a minimum threshold. Alternate levels of correction are possible (systematic terrain, systematic, or precision) for scenes acquired at night or that otherwise represent a reduced quality ground image (e.g., cloud cover).\n",
+    "\n",
+    "For daytime images, if the VNIR or SWIR telescope collected data and precision correction was attempted, each precision terrain corrected image will have an accompanying independent quality assessment. It will include the geometric correction available for distribution in both as a text file and a single band browse images with the valid GCPs overlaid.\n",
+    "\n",
+    "This multi-file product also includes georeferenced full resolution browse images. The number of browse images and the band combinations of the images depends on the bands available in the corresponding (AST_L1A) (https://doi.org/10.5067/ASTER/AST_L1A.003) dataset. \n",
+    "\n",
+    "### Additional Resources\n",
+    "- [How to recognize a COG and how to create a proper one!](https://cogeotiff.github.io/rio-cogeo/Is_it_a_COG/)\n",
+    "- [Rasterio documentation](https://rasterio.readthedocs.io/en/stable/intro.html)\n",
+    "- [ASTER Level 1 precision terrain corrected registered at-sensor radiance V003 dataset landing page](https://dx.doi.org/10.5067/ASTER/AST_L1T.003)\n",
+    "- [rio-cogeo Documentation](https://pypi.org/project/rio-cogeo/1.1.5/)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f012ee4b-32d9-4a3a-8840-46645bce468b",
+   "metadata": {},
+   "source": [
+    "### Importing Packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14bf64a1-85c0-45ee-9049-f3a8fda4ed7d",
+   "metadata": {},
+   "source": [
+    "We import the `os` module, import the `MAAP` package, and create a new MAAP class instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "id": "0dddf574-ce54-46cc-8de3-e84f1cf4fbfc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import os module\n",
+    "import os\n",
+    "import rasterio\n",
+    "import numpy\n",
+    "from rasterio.io import MemoryFile\n",
+    "from rasterio.rio import options\n",
+    "from rio_cogeo.cogeo import cog_translate\n",
+    "from rio_cogeo.profiles import cog_profiles\n",
+    "from rio_cogeo import cog_validate\n",
+    "\n",
+    "# import the MAAP package to handle queries\n",
+    "from maap.maap import MAAP\n",
+    "\n",
+    "# import printing package to help display outputs\n",
+    "from pprint import pprint\n",
+    "\n",
+    "# invoke the MAAP search client\n",
+    "maap = MAAP()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a3d343e-2bcd-43e9-b12b-e61e180460ac",
+   "metadata": {},
+   "source": [
+    "### Creating a Data Directory for this Tutorial\n",
+    "\n",
+    "We are creating a data directory for downloading all the required files to this directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "38bb61f1-d48c-47b6-9b9d-503eefde5b64",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# set data directory path\n",
+    "dataDir = './data'\n",
+    "\n",
+    "# check if directory exists -> if directory doesn't exist, directory is created\n",
+    "if not os.path.exists(dataDir):\n",
+    "    os.mkdir(dataDir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "510b3b55-2da3-476f-b9b1-9c828e5e9afb",
+   "metadata": {},
+   "source": [
+    "### Accessing the dataset\n",
+    "\n",
+    "The `searchCollection()` method of the maap-py is used for searching the collection on the NASA CMR, with the short name as `AST_L1T`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "2fa099a6-6678-4f25-9d5e-c94ab879e17a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "maap_collections = maap.searchCollection(\n",
+    "    short_name='AST_L1T',\n",
+    "    cmr_host='cmr.earthdata.nasa.gov')\n",
+    "# maap_collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "ea3a4c25-6658-4f1c-bc85-7bf280a55871",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'Got 20 results'\n"
+     ]
+    }
+   ],
+   "source": [
+    "COLLECTION_ID = maap_collections[0][\"concept-id\"]\n",
+    "\n",
+    "results = maap.searchGranule(\n",
+    "    concept_id=COLLECTION_ID,\n",
+    "    cmr_host=\"cmr.earthdata.nasa.gov\"\n",
+    ")\n",
+    "pprint(f'Got {len(results)} results')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5af49c7a-ea5b-4d1a-81bd-8e23d3a8b58f",
+   "metadata": {},
+   "source": [
+    "We will be using the `downloadGranule()` method from the maap-py to download the required GeoTIFF file. Let's first explore the metadata of a Granule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "4b5c973e-36a0-4e51-b889-444202df577e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Granule': {'AdditionalAttributes': {...},\n",
+      "             'Campaigns': {...},\n",
+      "             'CloudCover': '75',\n",
+      "             'Collection': {...},\n",
+      "             'DataFormat': 'HDF-EOS2',\n",
+      "             'DataGranule': {...},\n",
+      "             'GranuleUR': 'SC:AST_L1T.003:2148809731',\n",
+      "             'InputGranules': {...},\n",
+      "             'InsertTime': '2015-04-09T09:28:24.676Z',\n",
+      "             'LastUpdate': '2018-07-09T14:35:36.464Z',\n",
+      "             'MeasuredParameters': {...},\n",
+      "             'OnlineAccessURLs': {...},\n",
+      "             'OnlineResources': {...},\n",
+      "             'Orderable': 'true',\n",
+      "             'PGEVersionClass': {...},\n",
+      "             'Platforms': {...},\n",
+      "             'Spatial': {...},\n",
+      "             'Temporal': {...},\n",
+      "             'Visible': 'true'},\n",
+      " 'collection-concept-id': 'C1000000320-LPDAAC_ECS',\n",
+      " 'concept-id': 'G1012302826-LPDAAC_ECS',\n",
+      " 'format': 'application/echo10+xml',\n",
+      " 'revision-id': '15'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# print the metadata for the first collection\n",
+    "# we use the depth parameter to set the layer of metadata detail in the results, with (1) having the least detail\n",
+    "# (1) displays the concept ID, format, and revision ID\n",
+    "# adjust the depth to a larger value (6) if you would like to view all of the metadata\n",
+    "pprint(results[0], depth=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cba3d94-527d-4373-930c-cfb0a2e8ac65",
+   "metadata": {},
+   "source": [
+    "The `downloadGranule()` method requires Granule's HTTP access URL and the path to the data directory for storing the downloaded file. In order to get the online HTTP access URL, we will explore the metadata related to the `OnlineAccessURLs` key of the Granule. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "1cba66cd-9715-4a4d-a44a-191e6bc1c80f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'OnlineAccessURL': [{'URL': 'https://e4ftl01.cr.usgs.gov//ASTER_L1T/ASTT/AST_L1T.003/2000.03.04/AST_L1T_00303042000203404_20150409092553_2788.hdf',\n",
+       "   'URLDescription': 'AST_L1T_00303042000203404_20150409092553_2788.hdf. MimeType: application/x-hdfeos',\n",
+       "   'MimeType': 'application/x-hdfeos'},\n",
+       "  {'URL': 'https://e4ftl01.cr.usgs.gov//ASTER_L1T/ASTT/AST_L1T.003/2000.03.04/AST_L1T_00303042000203404_20150409092553_2788_T.tif',\n",
+       "   'URLDescription': 'AST_L1T_00303042000203404_20150409092553_2788_T.tif. MimeType: application/x-geotiff',\n",
+       "   'MimeType': 'application/x-geotiff'}]}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Checking the online access URLs\n",
+    "online_access_urls = results[0][\"Granule\"][\"OnlineAccessURLs\"]\n",
+    "online_access_urls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c0043b2-8e96-4d1c-aef7-41c3e3b0d02a",
+   "metadata": {},
+   "source": [
+    "As we can see above, the Granule has two access URLs, (1) for downloading the data in `h5` file format, and (2) for downloading the `tiff` file. We will be downloading the `tiff` file using the corresponding URL. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "727b4496-7f9d-4dc1-a4a5-38e8762399c1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://e4ftl01.cr.usgs.gov//ASTER_L1T/ASTT/AST_L1T.003/2000.03.04/AST_L1T_00303042000203404_20150409092553_2788_T.tif\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Extracting the URL for the tiff file\n",
+    "tiff_url = online_access_urls[\"OnlineAccessURL\"][1][\"URL\"]\n",
+    "print(tiff_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "id": "8b74668d-81ed-4df4-acb8-33577b6ccacc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "./data/AST_L1T_00303042000203404_20150409092553_2788_T.tif\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_path = maap.downloadGranule(tiff_url, dataDir, overwrite=True)\n",
+    "print(input_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e93046fb-5003-4777-a71e-a62a12059588",
+   "metadata": {},
+   "source": [
+    "### Loading the GeoTIFF file\n",
+    "\n",
+    "Once the file is downloaded locally, we can use `rasterio` to read the `tiff` file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "d42c3bba-cd2d-472c-b140-77dc8c359fd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with rasterio.open(input_path) as src:\n",
+    "    arr = src.read()\n",
+    "    kwargs = src.meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4db2fbe9-e918-4c7c-8335-ffcaa378563d",
+   "metadata": {},
+   "source": [
+    "### Writing the Cloud Optimized GeoTIFF (COG)\n",
+    "\n",
+    "There are multiple ways to write a COG using `rasterio` in Python. We are presenting the recommended approach based on `cog_translate` method using the Memoryfile. This approach is found to be efficient for writing big GeoTIFF files along with copying the overviews and input image metadata. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "914644c4-8e9c-4d24-8d7b-45e19f15ed18",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_3899/2588128130.py:11: RasterioDeprecationWarning: Source dataset should be opened in read-only mode. Use of datasets opened in modes other than 'r' will be disallowed in a future version.\n",
+      "  cog_translate(\n",
+      "Reading input: <open DatasetWriter name='/vsimem/c411e656-44e0-4606-933e-9aecc315f167/c411e656-44e0-4606-933e-9aecc315f167.tif' mode='w+'>\n",
+      "\n",
+      "Adding overviews...\n",
+      "Updating dataset tags...\n",
+      "Writing output to: ./data/AST_L1T_00303042000203404_20150409092553_2788_T_COG.tif\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_filename = input_path.split('/')[-1]\n",
+    "output_filename = input_filename.replace('.tif', '_COG.tif')\n",
+    "output_file = os.path.join(dataDir, output_filename)\n",
+    "\n",
+    "with MemoryFile() as memfile:\n",
+    "        with memfile.open(**kwargs) as mem:\n",
+    "            # Populate the input file with numpy array\n",
+    "            \n",
+    "            mem.write(arr)\n",
+    "            dst_profile = cog_profiles.get(\"deflate\")\n",
+    "            cog_translate(\n",
+    "                mem,\n",
+    "                output_file,\n",
+    "                dst_profile,\n",
+    "                in_memory=False\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0989558f-e806-4579-8a12-a0e8b5f9bcc5",
+   "metadata": {},
+   "source": [
+    "### Read generated COG output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "9e790755-7327-4b03-9ce6-15ef772e7e23",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "with rasterio.open(output_file) as src:\n",
+    "   arr_cog = src.read()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d253c5a2-c899-40c6-b624-a8973a6d91d7",
+   "metadata": {},
+   "source": [
+    "### Check if COG is a valid COG\n",
+    "\n",
+    "We will be using `cog_validate` method from the `rio-cogeo` to validate the generate COG output. The `cog_validate` method returns following outputs:\n",
+    "* `is_valid`: bool\n",
+    "    True if src_path is a valid COG.\n",
+    "* errors: list\n",
+    "    List of validation errors.\n",
+    "* warnings: list\n",
+    "    List of validation warnings."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "id": "43a030d9-abb0-4bee-b086-b315bf495af2",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "(True, [], [])"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Command line equivalent\n",
+    "#!rio cogeo validate {output_file}\n",
+    "\n",
+    "cog_validate(output_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c69037f9-c9c6-4fe5-b92d-e6202a0b3bf2",
+   "metadata": {},
+   "source": [
+    "### Run validation tests\n",
+    "\n",
+    "The `cog_validate` method runs on the COG file. Let's try to run a validation test on the arrays representing the COG and Non-COG file using Numpy's `assert_array_equal` [method](https://numpy.org/doc/stable/reference/generated/numpy.testing.assert_array_equal.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 31,
+   "id": "6de8de27-9697-45cb-806c-06ea3fd2be05",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "#Would not output anything if both the COG and non-COG files have equal values\n",
+    "numpy.testing.assert_array_equal(arr, arr_cog)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/source/technical_tutorials/user_data/writing-COGs-with-Python.ipynb
+++ b/docs/source/technical_tutorials/user_data/writing-COGs-with-Python.ipynb
@@ -1,0 +1,411 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "01d7d4bd-b8c6-4c8a-a390-723cb491e667",
+   "metadata": {},
+   "source": [
+    "# Writing Cloud-Optimized GeoTIFF (COG) with Python "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a97955bc-645a-40cd-9331-07c71d6bcc2e",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "Authors: Rajat Shinde (UAH), Sheyenne Kirkland (UAH), Alex Mandel (DevSeed), Jamison French (DevSeed), Brian Freitag (NASA MSFC)\n",
+    "\n",
+    "Date: January 29, 2024\n",
+    "\n",
+    "Description: In this tutorial, we will explore how to write Cloud-Optimized GeoTIFF outputs in Python.\n",
+    "\n",
+    "### Run This Notebook\n",
+    "To access and run this tutorial within MAAP's Algorithm Development Environment (ADE), please refer to the [\"Getting started with the MAAP\"](https://docs.maap-project.org/en/latest/getting_started/getting_started.html) section of our documentation.\n",
+    "\n",
+    "Disclaimer: It is highly recommended to run a tutorial within MAAP's ADE, which already includes packages specific to MAAP, such as maap-py. Running the tutorial outside of the MAAP ADE may lead to errors.\n",
+    "\n",
+    "### About The Dataset\n",
+    "For this tutorial, we are using the Advanced Spaceborne Thermal Emission and Reflection Radiometer (ASTER) Level 1 Precision Terrain Corrected Registered At-Sensor Radiance (AST_L1T) data. This data contains calibrated at-sensor radiance, which corresponds with the ASTER Level 1B (AST_L1B) (https://doi.org/10.5067/ASTER/AST_L1B.003), that has been geometrically corrected, and rotated to a north-up UTM projection. The AST_L1T is created from a single resampling of the corresponding ASTER L1A (AST_L1A) (https://doi.org/10.5067/ASTER/AST_L1A.003) product. The bands available in the AST_L1T depend on the bands in the AST_L1A and can include up to three Visible and Near Infrared (VNIR) bands, six Shortwave Infrared (SWIR) bands, and five Thermal Infrared (TIR) bands. The AST_L1T dataset does not include the aft-looking VNIR band 3.\n",
+    "\n",
+    "The precision terrain correction process incorporates GLS2000 digital elevation data with derived ground control points (GCPs) to achieve topographic accuracy for all daytime scenes where correlation statistics reach a minimum threshold. Alternate levels of correction are possible (systematic terrain, systematic, or precision) for scenes acquired at night or that otherwise represent a reduced quality ground image (e.g., cloud cover).\n",
+    "\n",
+    "For daytime images, if the VNIR or SWIR telescope collected data and precision correction was attempted, each precision terrain corrected image will have an accompanying independent quality assessment. It will include the geometric correction available for distribution in both as a text file and a single band browse images with the valid GCPs overlaid.\n",
+    "\n",
+    "This multi-file product also includes georeferenced full resolution browse images. The number of browse images and the band combinations of the images depends on the bands available in the corresponding (AST_L1A) (https://doi.org/10.5067/ASTER/AST_L1A.003) dataset. \n",
+    "\n",
+    "### Additional Resources\n",
+    "- [How to recognize a COG and how to create a proper one!](https://cogeotiff.github.io/rio-cogeo/Is_it_a_COG/)\n",
+    "- [Rasterio documentation](https://rasterio.readthedocs.io/en/stable/intro.html)\n",
+    "- [ASTER Level 1 precision terrain corrected registered at-sensor radiance V003 dataset landing page](https://dx.doi.org/10.5067/ASTER/AST_L1T.003)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f012ee4b-32d9-4a3a-8840-46645bce468b",
+   "metadata": {},
+   "source": [
+    "### Importing Packages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "14bf64a1-85c0-45ee-9049-f3a8fda4ed7d",
+   "metadata": {},
+   "source": [
+    "We import the `os` module, import the `MAAP` package, and create a new MAAP class instance."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0dddf574-ce54-46cc-8de3-e84f1cf4fbfc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# import os module\n",
+    "import os\n",
+    "import rasterio\n",
+    "from rasterio.io import MemoryFile\n",
+    "from rasterio.rio import options\n",
+    "from rio_cogeo.cogeo import cog_translate\n",
+    "from rio_cogeo.profiles import cog_profiles\n",
+    "\n",
+    "# import the MAAP package to handle queries\n",
+    "from maap.maap import MAAP\n",
+    "\n",
+    "# import printing package to help display outputs\n",
+    "from pprint import pprint\n",
+    "\n",
+    "# invoke the MAAP search client\n",
+    "maap = MAAP()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5a3d343e-2bcd-43e9-b12b-e61e180460ac",
+   "metadata": {},
+   "source": [
+    "### Creating a Data Directory for this Tutorial\n",
+    "\n",
+    "We are creating a data directory for downloading all the required files to this directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38bb61f1-d48c-47b6-9b9d-503eefde5b64",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# set data directory path\n",
+    "dataDir = './data'\n",
+    "\n",
+    "# check if directory exists -> if directory doesn't exist, directory is created\n",
+    "if not os.path.exists(dataDir):\n",
+    "    os.mkdir(dataDir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "510b3b55-2da3-476f-b9b1-9c828e5e9afb",
+   "metadata": {},
+   "source": [
+    "### Accessing the dataset\n",
+    "\n",
+    "The `searchCollection()` method of the maap-py is used for searching the collection on the NASA CMR, with the short name as `AST_L1T`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "id": "2fa099a6-6678-4f25-9d5e-c94ab879e17a",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "maap_collections = maap.searchCollection(\n",
+    "    short_name='AST_L1T',\n",
+    "    cmr_host='cmr.earthdata.nasa.gov')\n",
+    "# maap_collections"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 53,
+   "id": "ea3a4c25-6658-4f1c-bc85-7bf280a55871",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "'Got 20 results'\n"
+     ]
+    }
+   ],
+   "source": [
+    "COLLECTION_ID = maap_collections[0][\"concept-id\"]\n",
+    "\n",
+    "results = maap.searchGranule(\n",
+    "    concept_id=COLLECTION_ID,\n",
+    "    cmr_host=\"cmr.earthdata.nasa.gov\"\n",
+    ")\n",
+    "pprint(f'Got {len(results)} results')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5af49c7a-ea5b-4d1a-81bd-8e23d3a8b58f",
+   "metadata": {},
+   "source": [
+    "We will be using the `downloadGranule()` method from the maap-py to download the required GeoTIFF file. Let's first explore the metadata of a Granule."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 74,
+   "id": "4b5c973e-36a0-4e51-b889-444202df577e",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{'Granule': {'AdditionalAttributes': {...},\n",
+      "             'Campaigns': {...},\n",
+      "             'CloudCover': '75',\n",
+      "             'Collection': {...},\n",
+      "             'DataFormat': 'HDF-EOS2',\n",
+      "             'DataGranule': {...},\n",
+      "             'GranuleUR': 'SC:AST_L1T.003:2148809731',\n",
+      "             'InputGranules': {...},\n",
+      "             'InsertTime': '2015-04-09T09:28:24.676Z',\n",
+      "             'LastUpdate': '2018-07-09T14:35:36.464Z',\n",
+      "             'MeasuredParameters': {...},\n",
+      "             'OnlineAccessURLs': {...},\n",
+      "             'OnlineResources': {...},\n",
+      "             'Orderable': 'true',\n",
+      "             'PGEVersionClass': {...},\n",
+      "             'Platforms': {...},\n",
+      "             'Spatial': {...},\n",
+      "             'Temporal': {...},\n",
+      "             'Visible': 'true'},\n",
+      " 'collection-concept-id': 'C1000000320-LPDAAC_ECS',\n",
+      " 'concept-id': 'G1012302826-LPDAAC_ECS',\n",
+      " 'format': 'application/echo10+xml',\n",
+      " 'revision-id': '15'}\n"
+     ]
+    }
+   ],
+   "source": [
+    "# print the metadata for the first collection\n",
+    "# we use the depth parameter to set the layer of metadata detail in the results, with (1) having the least detail\n",
+    "# (1) displays the concept ID, format, and revision ID\n",
+    "# adjust the depth to a larger value (6) if you would like to view all of the metadata\n",
+    "pprint(results[0], depth=2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cba3d94-527d-4373-930c-cfb0a2e8ac65",
+   "metadata": {},
+   "source": [
+    "The `downloadGranule()` method requires Granule's HTTP access URL and the path to the data directory for storing the downloaded file. In order to get the online HTTP access URL, we will explore the metadata related to the `OnlineAccessURLs` key of the Granule. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 75,
+   "id": "1cba66cd-9715-4a4d-a44a-191e6bc1c80f",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'OnlineAccessURL': [{'URL': 'https://e4ftl01.cr.usgs.gov//ASTER_L1T/ASTT/AST_L1T.003/2000.03.04/AST_L1T_00303042000203404_20150409092553_2788.hdf',\n",
+       "   'URLDescription': 'AST_L1T_00303042000203404_20150409092553_2788.hdf. MimeType: application/x-hdfeos',\n",
+       "   'MimeType': 'application/x-hdfeos'},\n",
+       "  {'URL': 'https://e4ftl01.cr.usgs.gov//ASTER_L1T/ASTT/AST_L1T.003/2000.03.04/AST_L1T_00303042000203404_20150409092553_2788_T.tif',\n",
+       "   'URLDescription': 'AST_L1T_00303042000203404_20150409092553_2788_T.tif. MimeType: application/x-geotiff',\n",
+       "   'MimeType': 'application/x-geotiff'}]}"
+      ]
+     },
+     "execution_count": 75,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "#Checking the online access URLs\n",
+    "online_access_urls = results[0][\"Granule\"][\"OnlineAccessURLs\"]\n",
+    "online_access_urls"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7c0043b2-8e96-4d1c-aef7-41c3e3b0d02a",
+   "metadata": {},
+   "source": [
+    "As we can see above, the Granule has two access URLs, (1) for downloading the data in `h5` file format, and (2) for downloading the `tiff` file. We will be downloading the `tiff` file using the corresponding URL. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 76,
+   "id": "727b4496-7f9d-4dc1-a4a5-38e8762399c1",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://e4ftl01.cr.usgs.gov//ASTER_L1T/ASTT/AST_L1T.003/2000.03.04/AST_L1T_00303042000203404_20150409092553_2788_T.tif\n"
+     ]
+    }
+   ],
+   "source": [
+    "#Extracting the URL for the tiff file\n",
+    "tiff_url = online_access_urls[\"OnlineAccessURL\"][1][\"URL\"]\n",
+    "print(tiff_url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 78,
+   "id": "8b74668d-81ed-4df4-acb8-33577b6ccacc",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "./data/AST_L1T_00303042000203404_20150409092553_2788_T.tif\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_path = maap.downloadGranule(tiff_url, dataDir, overwrite=True)\n",
+    "print(input_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e93046fb-5003-4777-a71e-a62a12059588",
+   "metadata": {},
+   "source": [
+    "### Loading the GeoTIFF file\n",
+    "\n",
+    "Once the file is downloaded locally, we can use `rasterio` to read the `tiff` file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d42c3bba-cd2d-472c-b140-77dc8c359fd2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with rasterio.open(input_path) as src:\n",
+    "    arr_cog = src.read()\n",
+    "    kwargs = src.meta"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4db2fbe9-e918-4c7c-8335-ffcaa378563d",
+   "metadata": {},
+   "source": [
+    "### Writing the Cloud Optimized GeoTIFF (COG)\n",
+    "\n",
+    "There are multiple ways to write a COG using `rasterio` in Python. We are presenting the recommended approach based on `cog_translate` method using the Memoryfile. This approach is found to be efficient for writing big GeoTIFF files along with copying the overviews and input image metadata. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 79,
+   "id": "914644c4-8e9c-4d24-8d7b-45e19f15ed18",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/tmp/ipykernel_701/2671245585.py:11: RasterioDeprecationWarning: Source dataset should be opened in read-only mode. Use of datasets opened in modes other than 'r' will be disallowed in a future version.\n",
+      "  cog_translate(\n",
+      "Reading input: <open DatasetWriter name='/vsimem/e15d1864-5c88-4c87-91ae-99c2c7edb491/e15d1864-5c88-4c87-91ae-99c2c7edb491.tif' mode='w+'>\n",
+      "\n",
+      "Adding overviews...\n",
+      "Updating dataset tags...\n",
+      "Writing output to: ./data/AST_L1T_00303042000203404_20150409092553_2788_T_COG.tif\n"
+     ]
+    }
+   ],
+   "source": [
+    "input_filename = input_path.split('/')[-1]\n",
+    "output_filename = input_filename.replace('.tif', '_COG.tif')\n",
+    "output_file = os.path.join(dataDir, output_filename)\n",
+    "\n",
+    "with MemoryFile() as memfile:\n",
+    "        with memfile.open(**kwargs) as mem:\n",
+    "            # Populate the input file with numpy array\n",
+    "            \n",
+    "            mem.write(arr_cog)\n",
+    "            dst_profile = cog_profiles.get(\"deflate\")\n",
+    "            cog_translate(\n",
+    "                mem,\n",
+    "                output_file,\n",
+    "                dst_profile,\n",
+    "                in_memory=False\n",
+    "            )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0989558f-e806-4579-8a12-a0e8b5f9bcc5",
+   "metadata": {},
+   "source": [
+    "# Validating the COG output\n",
+    "\n",
+    "Check the [COG vs Non-COG validation](maap-documentation/docs/source/technical_tutorials/user_data/COG-NonCOG-validation.ipynb) notebook for validating the generated COG."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR consists of documentations for- 
1. Writing a (Cloud-Optimized GeoTIFF) COG output with Python
2. Validating the COG vs Non-COG

I have a few queries about the location for these documentations.
- The 1. notebook was initially planned for the [Cloud-Optimized Geospatial Formats Guide](https://guide.cloudnativegeo.org/). However, I realised that there is already a tutorial on [Examples of working with COGs](https://guide.cloudnativegeo.org/cloud-optimized-geotiffs/cogs-examples.html). So, 1. is re-written for MAAP ADE users. If we still plan to publish to the Guide, then I can create another copy for the guide based on this document.

- The 2. notebook is a detailed explanation of a brief [COG-validation MAAP Documentation Example](https://github.com/MAAP-Project/maap-documentation-examples/blob/main/cog-validation.ipynb). We can remove it if is redundant. However, keeping this still acts as a good end-to-end tutorial for COG validation. 

Reason for choosing ASTER_L1T dataset:
- Ongoing mission
- It has two `OnlineHTTPAccessURLs` and we don't have any example in MAAP Documentation for using one URL out of the two `OnlineHTTPAccessURLs`. So, it can act as a reference for such use-case. 

cc: @wildintellect @smk0033 
