### PR TITLE
added hysds <-> maap job status mapping

### DIFF
--- a/docs/source/system_reference_guide/jobs_maappy.ipynb
+++ b/docs/source/system_reference_guide/jobs_maappy.ipynb
@@ -75,7 +75,19 @@
     "\n",
     "```\n",
     "'<wps:StatusInfo xmlns:ows=\"http://www.opengis.net/ows/2.0\" xmlns:schemaLocation=\"http://schemas.opengis.net/wps/2.0/wps.xsd\" xmlns:wps=\"http://www.opengis.net/wps/2.0\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"><wps:JobID>86fbac52-24b0-4963-8b67-59d0fc09946a</wps:JobID><wps:Status>Succeeded</wps:Status></wps:StatusInfo>'\n",
-    "```"
+    "```\n",
+    "\n",
+    "### Job Status\n",
+    "Job status may be different between the HySDS Figaro job-monitoring dashboard and the Jobs UI. Below is a mapping of status terms:\n",
+    "```\n",
+    "MAAP <- HySDS\n",
+    "Accepted <- job-queued\n",
+    "Running <- job-started\n",
+    "Success <- job-completed\n",
+    "Failed <- job-offline or job-failed\n",
+    "\n",
+    "HySDS state not valid/used in MAAP: job-deduped\n",
+    "```\n"
    ]
   },
   {

--- a/docs/source/system_reference_guide/jobs_maappy.ipynb
+++ b/docs/source/system_reference_guide/jobs_maappy.ipynb
@@ -85,6 +85,7 @@
     "Running <- job-started\n",
     "Success <- job-completed\n",
     "Failed <- job-offline or job-failed\n",
+    "job-revoked <- job-revoked (when a queued or running job is stopped before completion)\n",
     "\n",
     "HySDS state not valid/used in MAAP: job-deduped\n",
     "```\n"

--- a/docs/source/system_reference_guide/jobsui.ipynb
+++ b/docs/source/system_reference_guide/jobsui.ipynb
@@ -43,6 +43,7 @@
     "Running <- job-started\n",
     "Success <- job-completed\n",
     "Failed <- job-offline or job-failed\n",
+    "job-revoked <- job-revoked (when a queued or running job is stopped before completion)\n",
     "\n",
     "HySDS state not valid/used in MAAP: job-deduped\n",
     "```\n"

--- a/docs/source/system_reference_guide/jobsui.ipynb
+++ b/docs/source/system_reference_guide/jobsui.ipynb
@@ -33,7 +33,19 @@
     "\n",
     "Users can sort jobs by queued, start, and end time in ascending/descending order. Users may use the search bar to filter the job list down to jobs containing the user-provided string in any of the fields shown.  \n",
     "\n",
-    "![jobs_ui_overview](../_static/jobs_ui_overview.png)\n"
+    "![jobs_ui_overview](../_static/jobs_ui_overview.png)\n",
+    "\n",
+    "### Job Status\n",
+    "Job status may be different between the HySDS Figaro job-monitoring dashboard and the Jobs UI. Below is a mapping of status terms:\n",
+    "```\n",
+    "MAAP <- HySDS\n",
+    "Accepted <- job-queued\n",
+    "Running <- job-started\n",
+    "Success <- job-completed\n",
+    "Failed <- job-offline or job-failed\n",
+    "\n",
+    "HySDS state not valid/used in MAAP: job-deduped\n",
+    "```\n"
    ]
   },
   {


### PR DESCRIPTION
added to the maap.py and jobs ui pages:

### Job Status
Job status may be different between the HySDS Figaro job-monitoring dashboard and the Jobs UI. Below is a mapping of status terms:
```
MAAP <- HySDS
Accepted <- job-queued
Running <- job-started
Success <- job-completed
Failed <- job-offline or job-failed

HySDS state not valid/used in MAAP: job-deduped
```
