### PR TITLE
Set display to none on rtd-version-warning tag to css

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -26,3 +26,7 @@
 .wy-nav-content-wrap {
   background: #fcfcfc;
 }
+
+.rtd-version-warning {
+  display: none;
+}


### PR DESCRIPTION
## What I Changed

Add display configuration for the version warning.

## How to Test It

Spin up the docs locally and verify that the warning message is no longer appearing.

## Other Notes

Relates to #442, but does not entirely close it as versioning is still an issue.

I found https://github.com/readthedocs/readthedocs.org/issues/11474 on addons. There seems to be no clear option for disabling addons at the time. We can [change the configuration](https://sphinx-rtd-theme.readthedocs.io/en/latest/configuring.html) used for themes, but that does not allow us to disable the warning.