### PR TITLE
Granule name changed

### DIFF
--- a/docs/source/technical_tutorials/access/direct_access.ipynb
+++ b/docs/source/technical_tutorials/access/direct_access.ipynb
@@ -633,7 +633,7 @@
     }
    ],
    "source": [
-    "nsidc_object = \"s3://nsidc-cumulus-prod-protected/ATLAS/ATL08/006/2023/06/21/ATL08_20230621235543_00272011_006_01.h5\"\n",
+    "nsidc_object = \"s3://nsidc-cumulus-prod-protected/ATLAS/ATL08/006/2023/06/21/ATL08_20230621235543_00272011_006_02.h5\"\n",
     "with s3_fsspec.open(nsidc_object) as f:\n",
     "    ds = xarray.open_dataset(f, group='gt1l/land_segments', engine=\"h5netcdf\", phony_dims='sort')\n",
     "ds"


### PR DESCRIPTION
01 became 02, likely a new reprocessing of the granule. In the future for some examples we probably need to rely on CMR/STAC queries to find the correct granule files.