### PR TITLE
fix: load Proj and Leaflet js and css for R notebooks

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -16,6 +16,21 @@ import os
 
 def setup(app):
     app.add_css_file('custom.css')
+    # Add Leaflet CSS and JS for R htmlwidgets
+    app.add_css_file('https://unpkg.com/leaflet@1.9.4/dist/leaflet.css',
+                     integrity='sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=',
+                     crossorigin='anonymous')
+    app.add_js_file('https://unpkg.com/leaflet@1.9.4/dist/leaflet.js',
+                    integrity='sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=',
+                    crossorigin='anonymous')
+    # Add Proj4js and Leaflet.Proj for coordinate transformations
+    app.add_js_file('https://cdnjs.cloudflare.com/ajax/libs/proj4js/2.9.0/proj4.js',
+                    crossorigin='anonymous')
+    app.add_js_file('https://cdn.jsdelivr.net/npm/proj4leaflet@1.0.2/src/proj4leaflet.js',
+                    crossorigin='anonymous')
+    # Add Leaflet providers for base maps
+    app.add_js_file('https://unpkg.com/leaflet-providers@1.13.0/leaflet-providers.js',
+                    crossorigin='anonymous')
 
 
 # -- Project information -----------------------------------------------------
@@ -37,6 +52,12 @@ extensions = [
 ]
 
 nbsphinx_execute = 'never'
+
+# Enable RequireJS for HTML widgets (needed for R leaflet maps)
+nbsphinx_requirejs_path = 'https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js'
+nbsphinx_requirejs_options = {
+    'crossorigin': 'anonymous',
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/technical_tutorials/working_with_r/visualizing_with_titiler-pgstac.ipynb
+++ b/docs/source/technical_tutorials/working_with_r/visualizing_with_titiler-pgstac.ipynb
@@ -59,7 +59,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 1,
    "id": "e6ec781f-fb50-4088-a44d-77f5b7b7ec6d",
    "metadata": {},
    "outputs": [
@@ -67,7 +67,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "Linking to GEOS 3.12.1, GDAL 3.8.5, PROJ 9.4.0; sf_use_s2() is TRUE\n",
+      "Linking to GEOS 3.10.2, GDAL 3.4.1, PROJ 8.2.1; sf_use_s2() is TRUE\n",
       "\n"
      ]
     }
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 2,
    "id": "b1afbaf1-4727-4690-a521-da9effd0066b",
    "metadata": {},
    "outputs": [],
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 3,
    "id": "c2fd72b2-b4df-49d6-8e92-3df2037b013d",
    "metadata": {},
    "outputs": [
@@ -115,24 +115,21 @@
      "text": [
       "$search\n",
       "$search$hash\n",
-      "[1] \"2b1c56237655c787dc5598c8592f5010\"\n",
+      "[1] \"e1458a47fc19d7e34c06f3d8469fd4f6\"\n",
       "\n",
       "$search$search\n",
       "$search$search$collections\n",
       "[1] \"icesat2-boreal\"\n",
       "\n",
+      "$search$search$`filter-lang`\n",
+      "[1] \"cql2-json\"\n",
       "\n",
-      "$search$`_where`\n",
-      "[1] \"collection = ANY ('{icesat2-boreal}') \"\n",
-      "\n",
-      "$search$orderby\n",
-      "[1] \"datetime DESC, id DESC\"\n",
       "\n",
       "$search$lastused\n",
-      "[1] \"2025-07-16T15:33:48.879094Z\"\n",
+      "[1] \"2025-12-18T20:40:25.515213Z\"\n",
       "\n",
       "$search$usecount\n",
-      "[1] 5371\n",
+      "[1] 175\n",
       "\n",
       "$search$metadata\n",
       "$search$metadata$type\n",
@@ -174,8 +171,8 @@
       "1                                                                                                    https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/info\n",
       "2                                                                         https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/{tileMatrixSetId}/tilejson.json\n",
       "3 https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/{tileMatrixSetId}/tilejson.json?bidx=1&nodata=nan&colormap_name=gist_earth_r&rescale=0%2C400&assets=tif\n",
-      "4                                                                                   https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/{tileMatrixSetId}/map\n",
-      "5           https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/{tileMatrixSetId}/map?bidx=1&nodata=nan&colormap_name=gist_earth_r&rescale=0%2C400&assets=tif\n",
+      "4                                                                              https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/{tileMatrixSetId}/map.html\n",
+      "5      https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/{tileMatrixSetId}/map.html?bidx=1&nodata=nan&colormap_name=gist_earth_r&rescale=0%2C400&assets=tif\n",
       "6                                                                  https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/{tileMatrixSetId}/WMTSCapabilities.xml\n",
       "       rel                                           title templated\n",
       "1     self                                 Mosaic metadata        NA\n",
@@ -215,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 4,
    "id": "885863e6-96a7-4996-9b35-cc1622ba4468",
    "metadata": {},
    "outputs": [
@@ -260,7 +257,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 5,
    "id": "e6c0f9c7-a470-4050-bbca-143e4c7cc594",
    "metadata": {},
    "outputs": [
@@ -309,7 +306,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 6,
    "id": "a650c338-88fe-4c3f-9256-270228b76a91",
    "metadata": {},
    "outputs": [],
@@ -331,7 +328,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 7,
    "id": "08c9fc0c-0067-4eb2-bc20-66a0ab131acd",
    "metadata": {},
    "outputs": [],
@@ -348,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 8,
    "id": "8910470a-fe3f-4941-bd1a-6275663595cf",
    "metadata": {},
    "outputs": [
@@ -373,8 +370,8 @@
        "<script title=\"leaflet-providers-plugin\" src=\"data:application/javascript;base64,TGVhZmxldFdpZGdldC5tZXRob2RzLmFkZFByb3ZpZGVyVGlsZXMgPSBmdW5jdGlvbihwcm92aWRlciwgbGF5ZXJJZCwgZ3JvdXAsIG9wdGlvbnMpIHsKICB0aGlzLmxheWVyTWFuYWdlci5hZGRMYXllcihMLnRpbGVMYXllci5wcm92aWRlcihwcm92aWRlciwgb3B0aW9ucyksICJ0aWxlIiwgbGF5ZXJJZCwgZ3JvdXApOwp9Owo=\"></script>\n",
        "\t</head>\n",
        "\t<body>\n",
-       "\t\t<div class=\"leaflet html-widget html-fill-item\" id=\"htmlwidget-c1f5c8bf35f0f52ccc78\" style=\"width:100%;height:400px;\"></div>\n",
-       "<script type=\"application/json\" data-for=\"htmlwidget-c1f5c8bf35f0f52ccc78\">{\"x\":{\"options\":{\"crs\":{\"crsClass\":\"L.CRS.EPSG3857\",\"code\":null,\"proj4def\":null,\"projectedBounds\":null,\"options\":{}}},\"calls\":[{\"method\":\"addProviderTiles\",\"args\":[\"OpenStreetMap\",null,\"Base Map\",{\"errorTileUrl\":\"\",\"noWrap\":false,\"detectRetina\":false}]},{\"method\":\"addTiles\",\"args\":[\"https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=tif&rescale=0%2C400&colormap_name=gist_earth_r&bidx=1\",null,\"icesat2-boreal - agb\",{\"minZoom\":0,\"maxZoom\":24,\"tileSize\":256,\"subdomains\":\"abc\",\"errorTileUrl\":\"\",\"tms\":false,\"noWrap\":false,\"zoomOffset\":0,\"zoomReverse\":false,\"opacity\":1,\"zIndex\":1,\"detectRetina\":false}]},{\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[-179.9,179.9,179.9,-179.9,-179.9],\"lat\":[51.6,51.6,78,78,51.6]}]]],null,\"Collection bounds\",{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"orange\",\"weight\":2,\"opacity\":1,\"fill\":true,\"fillColor\":\"orange\",\"fillOpacity\":0,\"smoothFactor\":1,\"noClip\":false},null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]},{\"method\":\"addLayersControl\",\"args\":[\"Base Map\",[\"icesat2-boreal - agb\",\"Collection bounds\"],{\"collapsed\":false,\"autoZIndex\":true,\"position\":\"topright\"}]}],\"limits\":{\"lat\":[51.6,78],\"lng\":[-179.9,179.9]},\"setView\":[[64.8,0],5,[]]},\"evals\":[],\"jsHooks\":[]}</script>\n",
+       "\t\t<div class=\"leaflet html-widget html-fill-item\" id=\"htmlwidget-99c31fff9fceb9c81f1e\" style=\"width:100%;height:400px;\"></div>\n",
+       "<script type=\"application/json\" data-for=\"htmlwidget-99c31fff9fceb9c81f1e\">{\"x\":{\"options\":{\"crs\":{\"crsClass\":\"L.CRS.EPSG3857\",\"code\":null,\"proj4def\":null,\"projectedBounds\":null,\"options\":{}}},\"calls\":[{\"method\":\"addProviderTiles\",\"args\":[\"OpenStreetMap\",null,\"Base Map\",{\"errorTileUrl\":\"\",\"noWrap\":false,\"detectRetina\":false}]},{\"method\":\"addTiles\",\"args\":[\"https://titiler-pgstac.maap-project.org/collections/icesat2-boreal/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=tif&rescale=0%2C400&colormap_name=gist_earth_r&bidx=1\",null,\"icesat2-boreal - agb\",{\"minZoom\":0,\"maxZoom\":24,\"tileSize\":256,\"subdomains\":\"abc\",\"errorTileUrl\":\"\",\"tms\":false,\"noWrap\":false,\"zoomOffset\":0,\"zoomReverse\":false,\"opacity\":1,\"zIndex\":1,\"detectRetina\":false}]},{\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[-179.9,179.9,179.9,-179.9,-179.9],\"lat\":[51.6,51.6,78,78,51.6]}]]],null,\"Collection bounds\",{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"orange\",\"weight\":2,\"opacity\":1,\"fill\":true,\"fillColor\":\"orange\",\"fillOpacity\":0,\"smoothFactor\":1,\"noClip\":false},null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]},{\"method\":\"addLayersControl\",\"args\":[\"Base Map\",[\"icesat2-boreal - agb\",\"Collection bounds\"],{\"collapsed\":false,\"autoZIndex\":true,\"position\":\"topright\"}]}],\"limits\":{\"lat\":[51.6,78],\"lng\":[-179.9,179.9]},\"setView\":[[64.8,0],5,[]]},\"evals\":[],\"jsHooks\":[]}</script>\n",
        "\t</body>\n",
        "</html>\n"
       ],
@@ -441,7 +438,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 9,
    "id": "9d8cbd30-0131-4047-8c71-163cc920b803",
    "metadata": {},
    "outputs": [
@@ -450,14 +447,14 @@
      "output_type": "stream",
      "text": [
       "$id\n",
-      "[1] \"058af6b76d8fc4e092818a0d1f7bffa8\"\n",
+      "[1] \"1bf89df0c73f2789c69e3c8ae3e5549f\"\n",
       "\n",
       "$links\n",
       "                                                                                                                      href\n",
-      "1                                   https://titiler-pgstac.maap-project.org/searches/058af6b76d8fc4e092818a0d1f7bffa8/info\n",
-      "2        https://titiler-pgstac.maap-project.org/searches/058af6b76d8fc4e092818a0d1f7bffa8/{tileMatrixSetId}/tilejson.json\n",
-      "3                  https://titiler-pgstac.maap-project.org/searches/058af6b76d8fc4e092818a0d1f7bffa8/{tileMatrixSetId}/map\n",
-      "4 https://titiler-pgstac.maap-project.org/searches/058af6b76d8fc4e092818a0d1f7bffa8/{tileMatrixSetId}/WMTSCapabilities.xml\n",
+      "1                                   https://titiler-pgstac.maap-project.org/searches/1bf89df0c73f2789c69e3c8ae3e5549f/info\n",
+      "2        https://titiler-pgstac.maap-project.org/searches/1bf89df0c73f2789c69e3c8ae3e5549f/{tileMatrixSetId}/tilejson.json\n",
+      "3             https://titiler-pgstac.maap-project.org/searches/1bf89df0c73f2789c69e3c8ae3e5549f/{tileMatrixSetId}/map.html\n",
+      "4 https://titiler-pgstac.maap-project.org/searches/1bf89df0c73f2789c69e3c8ae3e5549f/{tileMatrixSetId}/WMTSCapabilities.xml\n",
       "       rel                              title templated\n",
       "1 metadata                    Mosaic metadata        NA\n",
       "2 tilejson   Link for TileJSON (Template URL)      TRUE\n",
@@ -500,7 +497,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 10,
    "id": "604ab20f-a30f-4da2-a8f8-087613d54844",
    "metadata": {},
    "outputs": [
@@ -512,7 +509,7 @@
       "[1] \"2.2.0\"\n",
       "\n",
       "$name\n",
-      "[1] \"058af6b76d8fc4e092818a0d1f7bffa8\"\n",
+      "[1] \"1bf89df0c73f2789c69e3c8ae3e5549f\"\n",
       "\n",
       "$version\n",
       "[1] \"1.0.0\"\n",
@@ -521,7 +518,7 @@
       "[1] \"xyz\"\n",
       "\n",
       "$tiles\n",
-      "[1] \"https://titiler-pgstac.maap-project.org/searches/058af6b76d8fc4e092818a0d1f7bffa8/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=tif&rescale=0%2C400&colormap_name=gist_earth_r&bidx=1\"\n",
+      "[1] \"https://titiler-pgstac.maap-project.org/searches/1bf89df0c73f2789c69e3c8ae3e5549f/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=tif&rescale=0%2C400&colormap_name=gist_earth_r&bidx=1\"\n",
       "\n",
       "$minzoom\n",
       "[1] 0\n",
@@ -566,7 +563,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 11,
    "id": "c8b75c0d-1a80-4c70-9558-3877fed362cd",
    "metadata": {},
    "outputs": [
@@ -591,8 +588,8 @@
        "<script title=\"leaflet-providers-plugin\" src=\"data:application/javascript;base64,TGVhZmxldFdpZGdldC5tZXRob2RzLmFkZFByb3ZpZGVyVGlsZXMgPSBmdW5jdGlvbihwcm92aWRlciwgbGF5ZXJJZCwgZ3JvdXAsIG9wdGlvbnMpIHsKICB0aGlzLmxheWVyTWFuYWdlci5hZGRMYXllcihMLnRpbGVMYXllci5wcm92aWRlcihwcm92aWRlciwgb3B0aW9ucyksICJ0aWxlIiwgbGF5ZXJJZCwgZ3JvdXApOwp9Owo=\"></script>\n",
        "\t</head>\n",
        "\t<body>\n",
-       "\t\t<div class=\"leaflet html-widget html-fill-item\" id=\"htmlwidget-44af320fd78f1d9c7577\" style=\"width:100%;height:400px;\"></div>\n",
-       "<script type=\"application/json\" data-for=\"htmlwidget-44af320fd78f1d9c7577\">{\"x\":{\"options\":{\"crs\":{\"crsClass\":\"L.CRS.EPSG3857\",\"code\":null,\"proj4def\":null,\"projectedBounds\":null,\"options\":{}}},\"calls\":[{\"method\":\"addProviderTiles\",\"args\":[\"OpenStreetMap\",null,\"Base Map\",{\"errorTileUrl\":\"\",\"noWrap\":false,\"detectRetina\":false}]},{\"method\":\"addTiles\",\"args\":[\"https://titiler-pgstac.maap-project.org/searches/058af6b76d8fc4e092818a0d1f7bffa8/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=tif&rescale=0%2C400&colormap_name=gist_earth_r&bidx=1\",null,\"Search Tiles\",{\"minZoom\":0,\"maxZoom\":24,\"tileSize\":256,\"subdomains\":\"abc\",\"errorTileUrl\":\"\",\"tms\":false,\"noWrap\":false,\"zoomOffset\":0,\"zoomReverse\":false,\"opacity\":1,\"zIndex\":1,\"detectRetina\":false}]},{\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[-179.9,179.9,179.9,-179.9,-179.9],\"lat\":[51.6,51.6,78,78,51.6]}]]],null,\"STAC search bounds\",{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"orange\",\"weight\":2,\"opacity\":1,\"fill\":true,\"fillColor\":\"orange\",\"fillOpacity\":0,\"smoothFactor\":1,\"noClip\":false},null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]},{\"method\":\"addLayersControl\",\"args\":[\"Base Map\",[\"Search Tiles\",\"STAC search bounds\"],{\"collapsed\":false,\"autoZIndex\":true,\"position\":\"topright\"}]}],\"limits\":{\"lat\":[51.6,78],\"lng\":[-179.9,179.9]},\"setView\":[[61.5,-154],6,[]]},\"evals\":[],\"jsHooks\":[]}</script>\n",
+       "\t\t<div class=\"leaflet html-widget html-fill-item\" id=\"htmlwidget-2909e124a57806fde5c7\" style=\"width:100%;height:400px;\"></div>\n",
+       "<script type=\"application/json\" data-for=\"htmlwidget-2909e124a57806fde5c7\">{\"x\":{\"options\":{\"crs\":{\"crsClass\":\"L.CRS.EPSG3857\",\"code\":null,\"proj4def\":null,\"projectedBounds\":null,\"options\":{}}},\"calls\":[{\"method\":\"addProviderTiles\",\"args\":[\"OpenStreetMap\",null,\"Base Map\",{\"errorTileUrl\":\"\",\"noWrap\":false,\"detectRetina\":false}]},{\"method\":\"addTiles\",\"args\":[\"https://titiler-pgstac.maap-project.org/searches/1bf89df0c73f2789c69e3c8ae3e5549f/tiles/WebMercatorQuad/{z}/{x}/{y}?assets=tif&rescale=0%2C400&colormap_name=gist_earth_r&bidx=1\",null,\"Search Tiles\",{\"minZoom\":0,\"maxZoom\":24,\"tileSize\":256,\"subdomains\":\"abc\",\"errorTileUrl\":\"\",\"tms\":false,\"noWrap\":false,\"zoomOffset\":0,\"zoomReverse\":false,\"opacity\":1,\"zIndex\":1,\"detectRetina\":false}]},{\"method\":\"addPolygons\",\"args\":[[[[{\"lng\":[-179.9,179.9,179.9,-179.9,-179.9],\"lat\":[51.6,51.6,78,78,51.6]}]]],null,\"STAC search bounds\",{\"interactive\":true,\"className\":\"\",\"stroke\":true,\"color\":\"orange\",\"weight\":2,\"opacity\":1,\"fill\":true,\"fillColor\":\"orange\",\"fillOpacity\":0,\"smoothFactor\":1,\"noClip\":false},null,null,null,{\"interactive\":false,\"permanent\":false,\"direction\":\"auto\",\"opacity\":1,\"offset\":[0,0],\"textsize\":\"10px\",\"textOnly\":false,\"className\":\"\",\"sticky\":true},null]},{\"method\":\"addLayersControl\",\"args\":[\"Base Map\",[\"Search Tiles\",\"STAC search bounds\"],{\"collapsed\":false,\"autoZIndex\":true,\"position\":\"topright\"}]}],\"limits\":{\"lat\":[51.6,78],\"lng\":[-179.9,179.9]},\"setView\":[[61.5,-154],6,[]]},\"evals\":[],\"jsHooks\":[]}</script>\n",
        "\t</body>\n",
        "</html>\n"
       ],
@@ -642,9 +639,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "R",
+   "display_name": "R 4.4.3",
    "language": "R",
-   "name": "ir"
+   "name": "ir4"
   },
   "language_info": {
    "codemirror_mode": "r",
@@ -652,7 +649,7 @@
    "mimetype": "text/x-r-source",
    "name": "R",
    "pygments_lexer": "r",
-   "version": "4.3.3"
+   "version": "4.4.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The R leaflet package embeds the javascript differently than the Python version so we need to manually load some dependencies to make the leaflet widgets work in R notebooks.

I tested it by building the docs site locally - the widgets work fine after loading these libraries (no change to the notebook code required).

Closes https://github.com/NASA-IMPACT/active-maap-sprint/issues/1326