### PR TITLE
ADE Docs Notice

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,8 @@
 
 Welcome to the MAAP User Documentation!
 =======================================
+.. attention::
+    MAAP is transitioning from the ADE to Jupyterhub, and new Jupyterhub documentation is being added. For access to *ADE only* documentation, please see the `last-ade-release <https://docs.maap-project.org/en/last-ade-release/>`_. 
 
 .. toctree::
   :maxdepth: 1

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,7 +6,11 @@
 Welcome to the MAAP User Documentation!
 =======================================
 .. attention::
-    MAAP is transitioning from the ADE to Jupyterhub, and new Jupyterhub documentation is being added. For access to *ADE only* documentation, please see the `last-ade-release <https://docs.maap-project.org/en/last-ade-release/>`_. 
+    MAAP is transitioning from the MAAP ADE to the MAAP Hub for interactive Jupyterhub coding environments. The documentation now reflects the MAAP Hub as the default. 
+    
+    If you need to look up information specific to the MAAP ADE, please see `last-ade-release <https://docs.maap-project.org/en/last-ade-release/>`_. 
+
+    Documentation around all other aspects of MAAP remains unchanged, including the use of maap-py and DPS.
 
 .. toctree::
   :maxdepth: 1


### PR DESCRIPTION
Added a notice to the top of the docs home page to inform users where the last release is of ADE-only documentation is.