### PR TITLE
docs: make DPS STAC guide visible

### DIFF
--- a/docs/source/technical_tutorials.rst
+++ b/docs/source/technical_tutorials.rst
@@ -10,6 +10,7 @@ This section of the documentation includes hands-on tutorials with example algor
 
 
   technical_tutorials/dps_tutorial/dps_tutorial_demo.ipynb
+  technical_tutorials/dps_tutorial/dps_stac_metadata.ipynb
   technical_tutorials/searching.rst
   technical_tutorials/visualizing.rst
   technical_tutorials/accessing.rst


### PR DESCRIPTION
Add the DPS STAC metadata guide to the Technical Tutorials navigation.

resolves #597 
